### PR TITLE
fix(terraform): remove reserved PORT env from Cloud Run

### DIFF
--- a/terraform/cloudrun.tf
+++ b/terraform/cloudrun.tf
@@ -79,10 +79,7 @@ resource "google_cloud_run_v2_service" "portfolio" {
         container_port = 8080
       }
 
-      env {
-        name  = "PORT"
-        value = "8080"
-      }
+      # PORT is reserved; Cloud Run sets it automatically (8080).
       env {
         name  = "NODE_ENV"
         value = "production"


### PR DESCRIPTION
Cloud Run reserves PORT; setting it in template causes Error 400. Removed the env block; Cloud Run still sets PORT=8080 automatically.

Made with [Cursor](https://cursor.com)