### PR TITLE
Chat fixes, docs, knowledge, version 1.0.0, lint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # AGENTS.md
 
+**For AI agents (Cursor, Claude Code, OpenClaw, etc.):** Read this file first. It defines how to run, build, deploy, debug, view logs, use admin APIs, and what constraints to follow (free-tier, security, no tests). Use it as the single source of truth for agent tasks in this repo.
+
+---
+
 ## Cursor Cloud specific instructions
 
 ### Overview
@@ -413,7 +417,7 @@ gcloud compute ssl-certificates describe portfolio-ssl-cert --global
     "cloud_logging": { "status": "up" },
     "cloud_trace": { "status": "up" }
   },
-  "version": "3.0.0",
+  "version": "1.0.0",
   "region": "us-east1"
 }
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+## Humans
+
+- **Setup:** See [README.md](./README.md) (quick start, env vars, project structure).
+- **Deploy / infra:** See [docs/DEPLOY-CLOUDRUN.md](./docs/DEPLOY-CLOUDRUN.md) and [AGENTS.md](./AGENTS.md).
+
+## AI agents (Cursor, Claude Code, OpenClaw, etc.)
+
+**Use [AGENTS.md](./AGENTS.md) as the single source of truth.** It covers:
+
+- How to run (`npm run dev`), build (`npm run build`), and lint
+- Deployment: push to `main` → Cloud Build deploys; when to use Terraform
+- All routes (including admin: `/admin/conversations`, `/admin/logs`) and APIs
+- Environment variables and secrets (no keys in repo; use `.env.local` or Secret Manager)
+- Security: rate limits, prompt-injection defense, headers
+- **Viewing logs:** UI (`/admin/logs`), CLI (`gcloud logging read`), API (`GET /api/admin/logs` with `X-Admin-Secret`)
+- **Admin:** `ADMIN_SECRET` for sessions and logs; Firestore for chat analytics/memory
+- Gotchas: no test script, rate limits on in prod, War Room cache 10s
+- Free-tier and cost control (budget kill switch in `scripts/`)
+
+Before making changes, read the relevant section of AGENTS.md so your edits match run/deploy/debug and constraints.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ A Next.js portfolio with an AI-powered chat. Built with Next.js 16, TypeScript, 
 | IaC            | Terraform                           | Cloud Run, LB, WAF, secrets                 |
 | CI/CD          | Cloud Build                         | Push to `main` → build → deploy to Cloud Run |
 
+## For AI agents
+
+**Cursor, Claude Code, OpenClaw, and other AI coding agents:** Start with **[AGENTS.md](./AGENTS.md)**. It contains run/deploy/debug steps, admin and log access (UI + CLI + API), security and rate-limit rules, and repo layout. Use it as the canonical guide for any agent task in this repo.
+
 ## Prerequisites
 
 - Node.js 20.9+ (see `engines` in `package.json`; Next.js 16 requires 20.9+)

--- a/docs/DEBUGGING_CHAT.md
+++ b/docs/DEBUGGING_CHAT.md
@@ -1,5 +1,16 @@
 # Chat debugging guide
 
+## Quick API test (curl)
+
+To verify the chat API without the UI (e.g. after rate limits or to check answer content):
+
+```bash
+curl -s -X POST http://localhost:3000/api/chat -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"What is Luis good at?"}]}'
+```
+
+Expect a 200 response with plain text or streamed chunks. The UI strips `[Reasoning]` and `[Answer]` markers and shows only the answer. For 429, wait a minute (rate limit) or use a different IP.
+
 ## Where to look
 
 ### 0. War Room + Cloud Logging (when chat shows "Failed to get response")

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,4 +9,5 @@ Additional project documentation. For quick start and main reference, see the ro
 | [DEBUGGING_CHAT.md](./DEBUGGING_CHAT.md) | Chat / RAG debugging notes |
 | [DECISIONS.md](./DECISIONS.md) | Architecture and product decisions |
 | [QUESTIONS.md](./QUESTIONS.md) | Open questions and follow-ups |
-| [PLAN-CHAT-LOGGING.md](./PLAN-CHAT-LOGGING.md) | Plan: log all chat sessions for analytics (not yet implemented) |
+| [PLAN-CHAT-LOGGING.md](./PLAN-CHAT-LOGGING.md) | Chat session logging (implemented): Firestore, memory, engagement, admin |
+| [CHAT-SECRETS.md](./CHAT-SECRETS.md) | GCP Secret Manager: Firebase + admin secret setup for chat |

--- a/src/app/admin/logs/page.tsx
+++ b/src/app/admin/logs/page.tsx
@@ -33,8 +33,6 @@ export default function AdminLogsPage() {
     }
   }, []);
 
-  const authHeader = () => ({ 'X-Admin-Secret': storedSecret || secret });
-
   const fetchLogs = useCallback(async () => {
     const token = storedSecret || secret;
     if (!token) {
@@ -46,7 +44,9 @@ export default function AdminLogsPage() {
     try {
       const params = new URLSearchParams({ limit: '100', minutes: String(minutes) });
       if (severity) params.set('severity', severity);
-      const res = await fetch(`/api/admin/logs?${params}`, { headers: authHeader() });
+      const res = await fetch(`/api/admin/logs?${params}`, {
+        headers: { 'X-Admin-Secret': token },
+      });
       if (res.status === 401) {
         setError('Invalid secret');
         return;
@@ -68,6 +68,8 @@ export default function AdminLogsPage() {
 
   useEffect(() => {
     if (storedSecret && entries.length === 0 && !loading) fetchLogs();
+    // Intentionally only re-run when storedSecret changes (initial load); adding fetchLogs/loading/entries would re-fetch on every state change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [storedSecret]);
 
   const logout = () => {

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -248,6 +248,18 @@ export default function Chat() {
             });
           }
         }
+        // Final cleanup so stored message has no [Reasoning] blocks or duplicates
+        if (assistantContent) {
+          const cleaned = dedupeRepeatedResponse(normalizeAssistantContent(cleanAssistantContent(assistantContent)) || assistantContent);
+          if (cleaned !== assistantContent) {
+            setMessages((prev) => {
+              const next = [...prev];
+              const last = next[next.length - 1];
+              if (last?.role === 'assistant') last.content = cleaned;
+              return next;
+            });
+          }
+        }
       }
 
       incrementSessionMessageCount();
@@ -363,6 +375,7 @@ export default function Chat() {
               className="relative flex items-center gap-2 rounded-xl border border-border/60 bg-muted/30 p-1.5 focus-within:ring-2 focus-within:ring-primary/20 focus-within:border-primary/50 transition-all shadow-lg w-full max-w-4xl mx-auto"
             >
               <Input
+                data-testid="chat-input"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 placeholder="Ask about architecture, systems, or projects..."
@@ -370,6 +383,7 @@ export default function Chat() {
                 disabled={isLoading || showLimitMessage}
               />
               <Button
+                data-testid="chat-send"
                 type="submit"
                 size="icon"
                 className={cn(

--- a/src/lib/knowledge.ts
+++ b/src/lib/knowledge.ts
@@ -34,7 +34,7 @@ His title is SE II. His scope of impact — particularly in observability, produ
 ## Career Trajectory — The Real Story
 Luis started at The Home Depot in July 2022 as a contractor through Daugherty Business Solutions. He joined during the development of Card Broker (the primary credit/debit card routing service) before it was deployed to any stores.
 
-Over approximately two years, he contributed code, testing, rollout support, interrupt rotation, and observability work as Card Broker deployed across a nationwide store footprint.
+Over approximately four years, he contributed code, testing, rollout support, interrupt rotation, and observability work as Card Broker deployed across 2400+ stores (nationwide footprint).
 
 In January 2024, Home Depot broke their contract with Daugherty to hire Luis full-time — they saw enough value to poach him from his own contracting firm. Daugherty counter-offered with a substantial raise, GCP certification bonus, and a fully paid trip to AWS re:Invent. Luis chose Home Depot.
 
@@ -99,10 +99,11 @@ This is Luis's most visible individual contribution to the payments platform.
 - This work gave Luis visibility across the organization and demonstrated his ability to translate technical telemetry into business intelligence
 
 ## Contribution 2: Card Broker — Core Payment Routing (Major Contributor)
-Card Broker was Luis's primary project for approximately two years, from pre-deployment through production stabilization.
+Card Broker was Luis's primary project for approximately four years, from pre-deployment through production stabilization.
 
 - Contributed production code to Card Broker, the primary credit/debit card routing service
-- Supported the full lifecycle: development, testing, rollout across a nationwide store footprint, interrupt rotation, observability
+- Contributed production Go code to the primary credit-card routing service, participating in rollout across 2400+ stores and authoring operational runbooks for interrupt rotation
+- Supported the full lifecycle: development, testing, rollout across 2400+ stores, interrupt rotation, observability
 - Created operational runbooks for Card Broker support procedures
 - This is the foundational work that proved Luis's value and led to his full-time hire
 - To be clear: Luis did not design Card Broker. He was a contributor on the team that built and deployed it.

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -9,9 +9,10 @@
  *   LLM10 — Unbounded Consumption: length limits + message count caps
  */
 
-const MAX_MESSAGE_LENGTH = 1500;
+const MAX_USER_MESSAGE_LENGTH = 1500;
+const MAX_ASSISTANT_MESSAGE_LENGTH = 8000; // RAG answers can be long; only user input kept strict
 const MAX_MESSAGES_IN_CONTEXT = 8;
-const MAX_TOTAL_CHARS = 8000;
+const MAX_TOTAL_CHARS = 24000;
 
 const INJECTION_PATTERNS: RegExp[] = [
   /ignore\s+(all\s+)?(previous|prior|above|system)\s+(instructions|prompts|rules)/i,
@@ -71,10 +72,10 @@ export function sanitizeInput(content: string): SecurityCheckResult {
     return { safe: false, reason: "Invalid input." };
   }
 
-  if (content.length > MAX_MESSAGE_LENGTH) {
+  if (content.length > MAX_USER_MESSAGE_LENGTH) {
     return {
       safe: false,
-      reason: `Message too long. Please keep it under ${MAX_MESSAGE_LENGTH} characters.`,
+      reason: `Message too long. Please keep it under ${MAX_USER_MESSAGE_LENGTH} characters.`,
     };
   }
 
@@ -139,7 +140,8 @@ export function validateMessages(messages: unknown): SecurityCheckResult & { par
       return { safe: false, reason: "Invalid message content." };
     }
 
-    if (m.content.length > MAX_MESSAGE_LENGTH) {
+    const maxLen = m.role === "user" ? MAX_USER_MESSAGE_LENGTH : MAX_ASSISTANT_MESSAGE_LENGTH;
+    if (m.content.length > maxLen) {
       return { safe: false, reason: "Individual message too long." };
     }
 

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -271,7 +271,7 @@ export function getHealthData(): HealthData {
     timestamp: new Date().toISOString(),
     uptime_seconds: getUptimeSeconds(),
     checks,
-    version: "3.0.0",
+    version: "1.0.0",
     region: process.env.GOOGLE_CLOUD_REGION || "us-east1",
   };
 }


### PR DESCRIPTION
## Summary
- **Knowledge:** 2400+ stores (Card Broker rollout), 4 years in payments (not 2)
- **Security:** Relax message length for assistant (8k) so conversation history with long replies no longer triggers "Individual message too long"; user messages stay 1500, total 24k
- **Chat:** Post-stream cleanup for assistant content; data-testid for chat input/send; DEBUGGING_CHAT curl example
- **War Room / health:** Version 1.0.0 (was 3.0.0)
- **Docs:** AGENTS.md agent intro; README "For AI agents"; CONTRIBUTING.md; docs/README PLAN-CHAT-LOGGING + CHAT-SECRETS
- **Lint:** Admin logs useCallback (inline header), useEffect exhaustive-deps comment

Made with [Cursor](https://cursor.com)