### PR TITLE
Remove sensitive info, docs, automatic budget kill, verify steps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ CHAT_DAILY_BUDGET=900
 # =============================================================================
 # ANALYTICS — Google Analytics 4 (tag: portfolio, optional)
 # =============================================================================
-# NEXT_PUBLIC_GA_MEASUREMENT_ID=G-5E53HSER91
+# NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
 
 # =============================================================================
 # BUILD CONFIG

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ terraform/*.tfstate.*
 terraform/*.tfvars
 terraform/*.tfplan
 terraform/tfplan
+terraform/budget-kill.zip
 terraform/.terraform.lock.hcl
 
 # Legacy files (old CRA app — do not re-add)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -71,11 +71,12 @@ steps:
       - "--set-secrets"
       - "INFERENCIA_API_KEY=inferencia-api-key:latest,INFERENCIA_BASE_URL=inferencia-base-url:latest,FIREBASE_SERVICE_ACCOUNT_JSON=firebase-service-account:latest,ADMIN_SECRET=admin-secret:latest"
 
+# Set _GA_MEASUREMENT_ID in the Cloud Build trigger if you use Google Analytics 4.
 substitutions:
   _REGION: us-east1
   _SERVICE_NAME: lgportfolio
   _AR_REPO: portfolio
-  _GA_MEASUREMENT_ID: "G-5E53HSER91"
+  _GA_MEASUREMENT_ID: ""
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/functions/budget-kill/index.js
+++ b/functions/budget-kill/index.js
@@ -1,0 +1,64 @@
+/**
+ * Budget kill switch: when GCP Billing sends a budget alert to Pub/Sub,
+ * scale the portfolio Cloud Run service to 0 to stop request-driven cost.
+ * Triggered automatically at 50%, 90%, 100% of the $10 budget.
+ */
+
+const projectId = process.env.GOOGLE_CLOUD_PROJECT;
+const region = process.env.CLOUD_RUN_REGION || 'us-east1';
+const serviceName = process.env.CLOUD_RUN_SERVICE || 'lgportfolio';
+
+/**
+ * Cloud Function entry point (Pub/Sub message from budget alert).
+ * @param {import('@google-cloud/functions-framework').CloudEvent} cloudEvent
+ */
+export function scaleCloudRunToZero(cloudEvent) {
+  const raw = cloudEvent.data?.message?.data ?? cloudEvent.data?.data;
+  if (!raw) {
+    console.warn('No message data');
+    return;
+  }
+  let payload;
+  try {
+    payload = JSON.parse(Buffer.from(raw, 'base64').toString('utf8'));
+  } catch (e) {
+    console.warn('Failed to parse budget payload:', e.message);
+    return;
+  }
+  const threshold = payload.alertThresholdExceeded ?? payload.forecastThresholdExceeded;
+  console.log('Budget alert', {
+    budgetDisplayName: payload.budgetDisplayName,
+    costAmount: payload.costAmount,
+    budgetAmount: payload.budgetAmount,
+    alertThresholdExceeded: payload.alertThresholdExceeded,
+    forecastThresholdExceeded: payload.forecastThresholdExceeded,
+  });
+  if (threshold == null) {
+    console.log('No threshold exceeded in payload, skipping scale-down');
+    return;
+  }
+  return setCloudRunMaxInstances(0);
+}
+
+async function setCloudRunMaxInstances(maxInstances) {
+  if (!projectId) {
+    console.error('GOOGLE_CLOUD_PROJECT not set');
+    return;
+  }
+  const { GoogleAuth } = await import('google-auth-library');
+  const auth = new GoogleAuth({ scopes: ['https://www.googleapis.com/auth/cloud-platform'] });
+  const client = await auth.getClient();
+  const url = `https://run.googleapis.com/v2/projects/${projectId}/locations/${region}/services/${serviceName}?updateMask=template.scaling.maxInstanceCount`;
+  const res = await client.request({
+    method: 'PATCH',
+    url,
+    data: {
+      template: {
+        scaling: {
+          maxInstanceCount: maxInstances,
+        },
+      },
+    },
+  });
+  console.log('Cloud Run updated:', res.data?.name, 'maxInstanceCount:', maxInstances);
+}

--- a/functions/budget-kill/package.json
+++ b/functions/budget-kill/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "budget-kill",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "google-auth-library": "^9.0.0"
+  }
+}

--- a/scripts/disable-project-spend.sh
+++ b/scripts/disable-project-spend.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # Budget kill switch: stop request-driven spend by scaling Cloud Run to zero.
-# Run this when you hit your budget (e.g. $10) to disable the bleeding.
+# Manual fallback; when Terraform budget is configured (billing_account_id + budget_alert_email),
+# the same action runs automatically via Pub/Sub → budget-kill Cloud Function.
 #
 # Usage: ./scripts/disable-project-spend.sh [PROJECT_ID] [REGION]
 # Defaults: PROJECT_ID=lgportfolio, REGION=us-east1

--- a/terraform/budget-kill.tf
+++ b/terraform/budget-kill.tf
@@ -1,0 +1,117 @@
+# Automatic budget kill-switch: when budget threshold is exceeded, scale Cloud Run to 0.
+# Requires billing_account_id and budget_alert_email in terraform.tfvars.
+# Budget → Pub/Sub → Cloud Function → Cloud Run API (max-instances=0).
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+# Pub/Sub topic for budget notifications (GCP Billing publishes to this)
+resource "google_pubsub_topic" "budget_alerts" {
+  count = var.billing_account_id != "" && var.budget_alert_email != "" ? 1 : 0
+
+  name = "budget-alerts-portfolio"
+}
+
+# Allow GCP Billing to publish budget notifications to the topic
+resource "google_pubsub_topic_iam_member" "billing_publisher" {
+  count = var.billing_account_id != "" && var.budget_alert_email != "" ? 1 : 0
+
+  topic  = google_pubsub_topic.budget_alerts[0].name
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-billing.iam.gserviceaccount.com"
+}
+
+# Service account for the budget-kill function (needs Run Admin to scale service to 0)
+resource "google_service_account" "budget_kill" {
+  count = var.billing_account_id != "" && var.budget_alert_email != "" ? 1 : 0
+
+  account_id   = "budget-kill-fn"
+  display_name = "Budget kill switch Cloud Function"
+}
+
+resource "google_project_iam_member" "budget_kill_run_admin" {
+  count = var.billing_account_id != "" && var.budget_alert_email != "" ? 1 : 0
+
+  project = var.project_id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:${google_service_account.budget_kill[0].email}"
+}
+
+# Zip the budget-kill function source
+data "archive_file" "budget_kill" {
+  type        = "zip"
+  source_dir  = "${path.module}/../functions/budget-kill"
+  output_path = "${path.module}/budget-kill.zip"
+}
+
+# GCS bucket for function source (Gen2 requires source in GCS or repo)
+resource "google_storage_bucket" "functions" {
+  count = var.billing_account_id != "" && var.budget_alert_email != "" ? 1 : 0
+
+  name     = "${var.project_id}-functions-${data.google_project.project.number}"
+  location = var.region
+}
+
+resource "google_storage_bucket_object" "budget_kill_zip" {
+  count = var.billing_account_id != "" && var.budget_alert_email != "" ? 1 : 0
+
+  name   = "budget-kill-${data.archive_file.budget_kill.output_md5}.zip"
+  bucket = google_storage_bucket.functions[0].name
+  source = data.archive_file.budget_kill.output_path
+}
+
+# Cloud Function Gen2: triggered by budget Pub/Sub, scales Cloud Run to 0
+resource "google_cloudfunctions2_function" "budget_kill" {
+  count = var.billing_account_id != "" && var.budget_alert_email != "" ? 1 : 0
+
+  name        = "budget-kill"
+  location    = var.region
+  description = "Scales Cloud Run to 0 when budget threshold exceeded (automatic kill switch)"
+
+  build_config {
+    runtime     = "nodejs20"
+    entry_point = "scaleCloudRunToZero"
+    source {
+      storage_source {
+        bucket = google_storage_bucket.functions[0].name
+        object = google_storage_bucket_object.budget_kill_zip[0].name
+      }
+    }
+  }
+
+  service_config {
+    max_instance_count    = 1
+    available_memory      = "256Mi"
+    timeout_seconds       = 60
+    service_account_email = google_service_account.budget_kill[0].email
+    environment_variables = {
+      GOOGLE_CLOUD_PROJECT = var.project_id
+      CLOUD_RUN_REGION     = var.region
+      CLOUD_RUN_SERVICE    = "lgportfolio"
+    }
+  }
+
+  event_trigger {
+    trigger_region        = var.region
+    event_type            = "google.cloud.pubsub.topic.v1.messagePublished"
+    pubsub_topic          = google_pubsub_topic.budget_alerts[0].id
+    retry_policy          = "RETRY_POLICY_RETRY"
+    service_account_email = google_service_account.budget_kill[0].email
+  }
+
+  depends_on = [
+    google_project_service.apis,
+    google_storage_bucket_object.budget_kill_zip,
+  ]
+}
+
+# Allow the Eventarc trigger (running as budget_kill SA) to invoke the function
+resource "google_cloudfunctions2_function_iam_member" "budget_kill_invoker" {
+  count = var.billing_account_id != "" && var.budget_alert_email != "" ? 1 : 0
+
+  cloud_function = google_cloudfunctions2_function.budget_kill[0].name
+  location       = var.region
+  role           = "roles/run.invoker"
+  member         = "serviceAccount:${google_service_account.budget_kill[0].email}"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,6 +37,10 @@ terraform {
       source  = "hashicorp/google-beta"
       version = "~> 5.0"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.0"
+    }
   }
 }
 
@@ -59,6 +63,10 @@ locals {
     "secretmanager.googleapis.com",
     "compute.googleapis.com",
     "certificatemanager.googleapis.com",
+    "pubsub.googleapis.com",
+    "cloudfunctions.googleapis.com",
+    "eventarc.googleapis.com",
+    "cloudbuild.googleapis.com",
   ]
 }
 


### PR DESCRIPTION
## Summary
- **Sensitive:** Removed real GA measurement ID from `cloudbuild.yaml` (default `_GA_MEASUREMENT_ID: ""`) and `.env.example` (placeholder `G-XXXXXXXXXX`). Set in Cloud Build trigger or env if using GA4.
- **.gitignore:** `terraform/budget-kill.zip` (generated at Terraform apply).
- **README:** Recruiter-facing overhaul; verify section (build, lint, terraform validate).
- **AGENTS.md:** Verify-before-commit note; automatic budget kill description.
- **Automatic budget kill:** When Terraform budget is configured, Pub/Sub + Cloud Function scales Cloud Run to 0 on threshold (terraform/budget-kill.tf, functions/budget-kill). Budget wired to topic + schema_version.
- **Terraform:** APIs (pubsub, cloudfunctions, eventarc, cloudbuild), archive provider, budget-kill resources.
- **scripts/disable-project-spend.sh:** Note manual fallback when Terraform budget is set.

Made with [Cursor](https://cursor.com)