### PR TITLE
fix: remove Docs link from public nav

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -12,8 +12,7 @@ const navLinks = [
   { href: '/work', label: 'Work' },
   { href: '/architecture', label: 'Architecture' },
   { href: '/war-room', label: 'War Room' },
-  { href: '/docs', label: 'Docs' },
-  { href: '/about', label: 'About' },
+{ href: '/about', label: 'About' },
   { href: '/contact', label: 'Contact' },
 ];
 


### PR DESCRIPTION
## Summary
- Remove the `/docs` nav link from the public site navbar — docs are internal references, not meant for public navigation
- The `/docs` routes remain accessible via direct URL for internal use

## Test plan
- [ ] Verify no "Docs" link in desktop navbar
- [ ] Verify no "Docs" link in mobile hamburger menu
- [ ] Verify `/docs` still loads via direct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)