### PR TITLE
Add edge control plane workflows

### DIFF
--- a/docs/N8N-CONTROL-PLANE.md
+++ b/docs/N8N-CONTROL-PLANE.md
@@ -1,0 +1,823 @@
+# Edge Control Plane (n8n)
+
+This document defines the first production-grade automation workflows for the portfolio operating environment.
+
+- **Control plane:** `n8n.menezmethod.com` on a Raspberry Pi 5 with 24/7 uptime
+- **Application plane:** `gimenez.dev` on GCP Cloud Run
+- **Inference plane:** `llm.menezmethod.com` for self-hosted LLM calls
+
+The goal is not to build a vague AI assistant. The goal is to build a **policy-driven operator system** that detects problems, explains them, and takes bounded mitigation steps without improvising against production.
+
+**Current status**
+
+- `Site Sentinel`, `DNS / SSL Guardian`, `Deploy Guardian`, and `Cost Governor` are active on the Pi 5 control plane
+- workflow assets are versioned in-repo and re-importable onto the Pi
+- Slack channels for ops and approvals are wired into the workflow definitions
+- `Inference Router` is versioned and kept inactive until we expose a production-safe trigger
+- the two remaining platform gaps are:
+  - public webhook registration for `deploy-guardian` and `cost-governor`
+  - SQLite lock contention when using `n8n execute --id=...` against the live instance
+
+**Implementation note**
+
+- The Pi runtime supports `$env` in expressions and Code nodes, but not `process.env`.
+- External API calls are implemented with **HTTP Request nodes**, not Code-node `fetch`, to stay aligned with n8n’s supported execution model.
+- Safe drill mode is available through `CONTROL_PLANE_DRILL=1` so monitors can emit alerts without creating a real outage.
+
+---
+
+## Architecture stance
+
+This design follows a few principles taken from *The Architect's Playbook*:
+
+- **Application-layer intercepts, not prompts.**
+  Safety and control live in workflow logic, schemas, approvals, and policy tables.
+- **Route by SLA.**
+  Fast mitigation paths stay deterministic. AI runs in asynchronous triage and summaries.
+- **Validate every structured output.**
+  If a model returns malformed JSON or low-confidence analysis, retry with error feedback or send it to human review.
+- **Split broad tools into narrow tools.**
+  Avoid one giant "run shell" capability when a workflow only needs `check_dns`, `check_ssl`, or `set_cloud_run_max_instances`.
+- **Maintain structured state.**
+  Persist incidents, decisions, and prior mitigations outside model context.
+- **Parallelize independent checks.**
+  DNS, SSL, deploy health, Cloud Run status, budget state, and log summaries can run in parallel and then merge into one decision.
+
+That gives us a clean story:
+
+```text
+Pi 5 / n8n  ->  detects, classifies, approves, audits
+GCP         ->  hosts the site and enforces guardrails
+LLMs        ->  summarize, classify, recommend
+Humans      ->  approve destructive actions
+```
+
+---
+
+## Tool choices
+
+### Coordinator
+
+- **n8n on Pi 5**
+  - Best fit for workflow orchestration, approvals, timers, webhooks, and integration glue
+  - Independent failure domain from GCP
+  - Stronger architecture story than hosting everything in the same cloud
+
+### Enforcement layer
+
+- **GCP native controls**
+  - Cloud Monitoring uptime checks
+  - Cloud Run service configuration
+  - Billing alerts / budget notifications
+  - Cloud Logging and Cloud Trace
+
+### State
+
+- **Recommended:** PostgreSQL for incidents, decision logs, workflow state, and approval records
+- **Optional later:** Redis if queue mode or higher concurrency becomes necessary
+
+### Models
+
+- **Primary analysis:** `llm.menezmethod.com`
+  - private reasoning
+  - architecture explanations
+  - bounded incident classification
+- **Cheap overflow / summaries:** NVIDIA API
+  - incident summaries
+  - daily or weekly ops briefs
+  - low-cost secondary classifier
+
+### Access and approval
+
+- Slack, Telegram, or email for approvals
+- Tailscale or equivalent private admin access to the Pi
+- Audit every action taken by an agent
+
+---
+
+## Workflow inventory
+
+Start with four workflows and one reporting workflow.
+
+### 1. Site Sentinel
+
+**Purpose**
+
+Detect whether the public site is healthy and capture enough evidence to classify failures quickly.
+
+**Versioned asset**
+
+- Import file: `ops/n8n/workflows/site-sentinel.json`
+
+**Trigger**
+
+- Schedule every 5 minutes
+- Optional manual trigger webhook for testing
+
+**Checks**
+
+- `GET https://gimenez.dev/`
+- `GET https://gimenez.dev/api/health`
+- `GET https://gimenez.dev/war-room`
+- `GET https://gimenez.dev/api/war-room/data`
+- Cloud Run service status
+- latest deploy status from GitHub
+- managed SSL status
+
+**Parallel branches**
+
+- HTTP availability branch
+- SSL / certificate branch
+- Cloud Run state branch
+- GitHub deploy branch
+
+**Decision logic**
+
+- If all checks pass: write heartbeat event
+- If one check fails once: write degraded event and recheck in 60 seconds
+- If repeated failures: open incident record and trigger incident triage
+
+**Allowed actions**
+
+- create incident record
+- notify operator
+- trigger `Incident Triage`
+
+**Not allowed**
+
+- mutate production directly
+
+---
+
+### 2. DNS / SSL Guardian
+
+**Purpose**
+
+Catch the exact class of failure that took the site down: DNS drift, stale A records, SSL stuck provisioning, `FAILED_NOT_VISIBLE`, or missing hostname coverage.
+
+**Trigger**
+
+- Schedule every 30 minutes
+- Immediate trigger from Site Sentinel when HTTPS fails but HTTP still redirects
+
+**Inputs**
+
+- authoritative DNS lookup
+- multiple public resolver lookups
+- managed certificate status
+- HTTPS probe on apex and `www`
+
+**Decision logic**
+
+- DNS mismatch: raise `dns_drift`
+- cert `PROVISIONING` + DNS healthy: raise `ssl_waiting`
+- cert `FAILED_NOT_VISIBLE`: raise `ssl_visibility_failure`
+- `www` missing coverage: raise `hostname_coverage_gap`
+
+**Allowed actions**
+
+- send exact remediation message
+- create GitHub issue
+- post incident summary
+
+**Not allowed**
+
+- rewrite registrar DNS automatically
+
+That keeps the workflow useful and safe.
+
+---
+
+### 3. Deploy Guardian
+
+**Purpose**
+
+Watch merges and deploys, run smoke checks, and prevent a bad release from sitting broken.
+
+**Trigger**
+
+- GitHub Actions webhook
+- Cloud Build webhook if available
+
+**Inputs**
+
+- branch / commit SHA
+- deployment target
+- Cloud Run revision
+- smoke checks on `/`, `/about`, `/work`, `/chat`, `/war-room`, `/api/health`
+
+**Decision logic**
+
+- Deploy succeeded + smoke checks pass: mark healthy deploy
+- Deploy succeeded + smoke checks fail: open incident and recommend rollback
+- Deploy failed: open incident and attach logs
+
+**Allowed actions**
+
+- notify operator
+- create issue / incident
+- call rollback workflow only after approval
+
+**Optional later**
+
+- automatic rollback when:
+  - bad deploy signature is high confidence
+  - previous revision is known healthy
+  - action is explicitly enabled by policy
+
+**Implementation note**
+
+- `ops/n8n/workflows/deploy-guardian.json` combines a manual start and `deploy-guardian` webhook, runs the smoke checks documented above, emits a structured summary, and throws when two consecutive smoke-check runs fail to trigger an escalation path.
+
+---
+
+### 4. Cost Governor
+
+**Purpose**
+
+Control runaway spend without destroying the public presence unless a last resort is required.
+
+**Trigger**
+
+- Schedule every 10-15 minutes
+- GCP billing notification / webhook if configured
+
+**Inputs**
+
+- month-to-date spend
+- forecast spend
+- Cloud Run request volume
+- 429 / 5xx counts
+- chat request volume
+- Artifact Registry storage growth
+- current Cloud Run max instances
+
+**Mitigation ladder**
+
+1. warn only
+2. tighten expensive feature limits
+3. disable chat
+4. reduce Cloud Run max instances
+5. set max instances to `0` as emergency kill
+
+**Key rule**
+
+Never disable the public site domain path as a first-line cost action. Preserve public presence whenever possible.
+
+**Allowed actions**
+
+- adjust feature flags
+- hit a safe internal endpoint to disable chat
+- call `gcloud run services update ... --max-instances`
+
+**Approval boundary**
+
+- chat disable: optional auto
+- max instances to `0`: approval recommended unless budget breach policy explicitly allows autonomous shutdown
+
+---
+
+### 5. Incident Triage
+
+**Purpose**
+
+Take raw signals from other workflows and turn them into a precise operator report.
+
+**Trigger**
+
+- Called by Site Sentinel, Deploy Guardian, or DNS / SSL Guardian
+
+**Inputs**
+
+- incident type
+- latest health results
+- recent logs
+- current deploy SHA
+- DNS status
+- SSL status
+- budget state
+
+**Pattern**
+
+- deterministic data collection first
+- LLM summary second
+- typed output required
+
+**Typed output shape**
+
+```json
+{
+  "incident_type": "deploy_failure | ssl_visibility_failure | dns_drift | budget_risk | app_degraded",
+  "severity": "low | medium | high | critical",
+  "likely_cause": "string",
+  "evidence": ["string"],
+  "recommended_actions": ["string"],
+  "confidence": 0.0
+}
+```
+
+If validation fails, retry once with the validation error appended. If confidence remains low, route to human review.
+
+---
+
+### 6. Weekly Ops Brief
+
+**Purpose**
+
+Produce a VP-readable summary of operational maturity.
+
+**Trigger**
+
+- Weekly schedule
+
+**Contents**
+
+- uptime summary
+- deploy count
+- incidents detected
+- mitigations taken
+- cost trend
+- top recurring issues
+- recommended next improvements
+
+This is one of the best recruiter and executive artifacts because it shows the system is measured, not theatrical.
+
+---
+
+## Policy table
+
+Use explicit policy nodes or a small policy datastore.
+
+| Condition | Workflow action |
+|---|---|
+| site healthy, no anomaly | write heartbeat only |
+| one failed health check | recheck in 60 seconds |
+| repeated health failures | create incident and notify |
+| cert provisioning and DNS correct | notify, monitor, no mutation |
+| cert failed not visible | notify with exact DNS / SSL evidence |
+| deploy success but smoke fails | create incident, recommend rollback |
+| spend trend rising but site healthy | warn or tighten chat limits |
+| budget threshold breached | disable chat or reduce instances |
+| critical spend event | require approval or emergency kill depending on policy |
+
+---
+
+## Narrow tool set
+
+Avoid broad shell access in agent-facing steps.
+
+Recommended tools:
+
+- `check_site_health`
+- `check_war_room`
+- `check_ssl_status`
+- `check_dns_authoritative`
+- `check_dns_public`
+- `check_github_deploy`
+- `check_cloud_run_service`
+- `check_budget_state`
+- `disable_chat_feature`
+- `set_cloud_run_max_instances`
+- `create_incident_record`
+- `send_approval_request`
+- `post_ops_summary`
+
+Each tool should have:
+
+- clear input schema
+- clear output schema
+- single responsibility
+- explicit failure mode
+
+---
+
+## Human approval design
+
+Require approval for:
+
+- rollback
+- changing Cloud Run instance caps downward in a disruptive way
+- emergency shutdown
+- any DNS mutation
+
+Do not require approval for:
+
+- heartbeat logging
+- status checks
+- incident creation
+- report generation
+- chat summaries
+
+This keeps the workflows precise instead of turning them into a generic, over-trusting agent.
+
+---
+
+## Testing strategy
+
+Do not call a workflow "done" until it passes drills.
+
+### Drill 1: homepage synthetic outage
+
+- temporarily point Site Sentinel to a non-existent path or block the app path locally
+- expected result:
+  - failed health recorded
+  - retry happens
+  - incident created on repeated failure
+  - no destructive production action
+
+### Drill 2: bad deploy simulation
+
+- deploy a revision with a broken route or intentionally fail a smoke check in staging
+- expected result:
+  - Deploy Guardian catches it
+  - incident summary includes deploy SHA
+  - rollback recommendation is produced
+
+### Drill 3: SSL failure simulation
+
+- use a staging hostname with intentionally broken DNS or incomplete cert coverage
+- expected result:
+  - DNS / SSL Guardian identifies the failure class correctly
+  - apex vs `www` distinction is preserved
+
+### Drill 4: budget pressure simulation
+
+- feed Cost Governor mocked spend inputs above thresholds
+- expected result:
+  - mitigation ladder runs in the right order
+  - destructive action requires approval when policy says so
+
+### Drill 5: malformed LLM output
+
+- force Incident Triage to receive invalid JSON from the model
+- expected result:
+  - validation catches it
+  - retry includes error feedback
+  - human review is used if needed
+
+### Drill 6: Pi reboot recovery
+
+- restart the Pi or n8n container
+- expected result:
+  - workflows recover cleanly
+  - credentials and state remain intact
+  - no orphaned incidents or duplicated actions
+
+### Drill 7: control-plane drill mode
+
+- run the monitor workflows with `CONTROL_PLANE_DRILL=1`
+- expected result:
+  - Slack alerts are emitted even when the site is healthy
+  - the alert body clearly marks the run as a drill
+  - no production mutation occurs
+
+---
+
+## Minimum viable implementation order
+
+1. Site Sentinel
+2. DNS / SSL Guardian
+3. Deploy Guardian
+4. Incident Triage
+5. Cost Governor
+6. Weekly Ops Brief
+
+This order gives immediate portfolio value while keeping risk low.
+
+---
+
+## Access required for live implementation
+
+To wire this onto the Pi and GCP directly, the minimum access needed is:
+
+- SSH access to the Pi 5 hosting `n8n`
+- access to the `n8n` environment or container definitions
+- a service account or CLI auth path for:
+  - Cloud Run read/update
+  - Cloud Monitoring read
+  - Cloud Billing alert integration
+  - Cloud Logging read
+- access to the GitHub repo webhooks or Actions status
+
+Recommended approach:
+
+- start with read-only checks and notifications
+- add safe mutations second
+- gate disruptive actions behind approval
+
+---
+
+## Why this is VP-impressive
+
+This is not "an AI assistant on a website."
+
+It is an **edge-hosted, out-of-band operator system** that:
+
+- supervises a cloud workload from an independent failure domain
+- protects uptime and budget with policy-driven automation
+- uses AI only where it adds leverage
+- keeps humans in the loop for risky changes
+- leaves behind an audit trail and executive-readable ops summaries
+
+That is the right story for Staff and Principal-track systems work.
+
+---
+
+## Skeptical VP review
+
+A skeptical VP is not going to ask whether the agents are clever. They are going to ask whether the system is **safe, durable, measurable, and worth trusting**.
+
+These are the obvious objections and the corresponding fixes.
+
+### Objection 1: "This is still a single hobby box."
+
+**Risk**
+
+- the Pi 5 is a strong edge-control-plane story, but it is still one physical device
+- if the Pi is down, the control plane disappears
+
+**Patch**
+
+- add a UPS or battery-backed power path
+- add a host-health workflow for the Pi itself
+- add off-device backups for the n8n database and workflow exports
+- migrate n8n from SQLite to Postgres if you want reliable CLI execution while the instance stays online
+- keep the most important kill switches in GCP-native controls so the platform is not fully dependent on n8n
+
+**What to prove**
+
+- Pi reboot recovery drill
+- restore workflow export to a second machine or container
+
+### Objection 2: "Your automation plane can take action, but where are the guardrails?"
+
+**Risk**
+
+- impressive automation without approval boundaries looks reckless
+- broad shell access turns the system into a security story instead of an architecture story
+
+**Patch**
+
+- keep action tools narrow and schema-validated
+- require approval for rollback, shutdown, or disruptive scaling changes
+- separate read-only workflows from mutation workflows
+- expose only approved workflows through MCP
+- keep outbound calls in supported nodes like HTTP Request instead of custom runtime hacks
+
+**What to prove**
+
+- a workflow can recommend rollback without being able to invent one
+- destructive actions produce an approval record and audit trail
+
+### Objection 3: "What happens when your local model is down?"
+
+**Risk**
+
+- if the inference layer is single-homed to `llm.menezmethod.com`, the AI story looks brittle
+
+**Patch**
+
+- build an `Inference Router` workflow
+- local LLM is primary for private reasoning
+- NVIDIA API is secondary for summaries and classification
+- deterministic templates are the last fallback when all models are unavailable
+
+**What to prove**
+
+- the incident still gets triaged when the local LLM is unavailable
+- fallback routing is visible in the audit record
+
+### Objection 4: "Where is the business value?"
+
+**Risk**
+
+- a reliability demo without cost, deployment, and abuse controls can still look like engineering theater
+
+**Patch**
+
+- prioritize `Deploy Guardian`, `Cost Governor`, and `Abuse Sentinel`
+- measure avoided incidents, reduced time-to-diagnosis, and avoided spend
+- produce a weekly ops brief that an executive can actually read
+
+**What to prove**
+
+- prevented or shortened bad deploy impact
+- kept monthly cost under a target
+- detected and contained abnormal traffic or model abuse
+
+### Objection 5: "How do I know this is not just a nice dashboard?"
+
+**Risk**
+
+- if the system only observes, it looks like reporting instead of operations
+
+**Patch**
+
+- every major workflow needs a `sense -> decide -> act -> audit` chain
+- at least one workflow must take a safe autonomous action
+- the action must be reversible and bounded
+
+**What to prove**
+
+- cost or abuse workflow can safely disable chat without taking down the whole site
+- agent actions show the exact policy that fired
+
+### Objection 6: "Your security posture is weaker than your architecture slide."
+
+**Risk**
+
+- MCP is public
+- tokens can leak
+- the current n8n basic auth password is weak
+
+**Patch**
+
+- rotate n8n basic auth immediately
+- rotate MCP tokens after any exposure
+- prefer HTTPS-only MCP clients
+- keep mutation workflows private or approval-gated
+- add token and secret rotation to the operating checklist
+
+**What to prove**
+
+- token rotation does not break workflow operations
+- public MCP only exposes the intended workflow surface
+
+---
+
+## Execution roadmap
+
+The next phase is not "more agents." It is a **small reliability and cost-control program** with clear milestones.
+
+### Phase 0: hardening the control plane
+
+**Goal**
+
+Make the current Pi 5 + n8n control plane credible enough to trust for operational demos.
+
+**Work**
+
+- rotate n8n basic auth and MCP token
+- document MCP connection requirements and token hygiene
+- add `n8n` host-health monitoring
+- back up workflow exports and database snapshots off-device
+- move n8n storage from SQLite to Postgres so CLI drills and live runtime can coexist cleanly
+
+**Exit criteria**
+
+- compromised token can be rotated in minutes
+- workflow exports are recoverable
+- control plane health is monitored separately from app health
+
+### Phase 1: detect and explain
+
+**Goal**
+
+Detect failure classes quickly and package the evidence cleanly.
+
+**Work**
+
+- keep `Site Sentinel` as the heartbeat baseline
+- build `DNS / SSL Guardian`
+- build `Deploy Guardian`
+- build `Incident Triage`
+
+**Exit criteria**
+
+- every incident summary includes cause hypothesis, evidence, and next actions
+- at least three drills pass: bad deploy, DNS drift, cert failure
+
+### Phase 2: degrade safely
+
+**Goal**
+
+Show bounded autonomy that reduces blast radius without being reckless.
+
+**Work**
+
+- build `Cost Governor`
+- build `Abuse Sentinel`
+- add a safe `disable_chat` action path
+- add approval gates for disruptive actions
+
+**Exit criteria**
+
+- one workflow can take a reversible autonomous action
+- emergency shutdown remains approval-gated or explicitly policy-controlled
+
+### Phase 3: resilient AI operations
+
+**Goal**
+
+Prove that AI is infrastructure, not a fragile dependency.
+
+**Work**
+
+- build `Inference Router`
+- local LLM primary
+- NVIDIA fallback for summaries/classification
+- deterministic fallback when both models are unavailable
+- write the fallback decision into the incident audit record
+
+**Exit criteria**
+
+- incident triage still completes when the local model is down
+- operators can see which model path was used and why
+
+### Phase 4: executive operating system
+
+**Goal**
+
+Turn the system into something leadership can evaluate in one glance.
+
+**Work**
+
+- build `Weekly Ops Brief`
+- add metrics for:
+  - incidents detected
+  - avoided bad deploys
+  - mitigations taken
+  - avoided spend
+  - mean time to diagnosis
+- publish a portfolio case study with screenshots, system diagram, and drills
+
+**Exit criteria**
+
+- the control plane produces an executive-readable artifact every week
+- the site can demonstrate closed-loop operations, not just workflow count
+
+---
+
+## Recommended build order
+
+If the goal is to impress a skeptical VP quickly, build in this order:
+
+1. `DNS / SSL Guardian`
+2. `Deploy Guardian`
+3. `Inference Router`
+4. `Cost Governor`
+5. `Abuse Sentinel`
+6. `Incident Triage`
+7. `Weekly Ops Brief`
+
+Why this order:
+
+- `DNS / SSL Guardian` proves operational scar tissue
+- `Deploy Guardian` proves engineering judgment
+- `Inference Router` patches the AI resiliency hole
+- `Cost Governor` proves business awareness
+- `Abuse Sentinel` proves security awareness
+- `Incident Triage` and `Weekly Ops Brief` turn the whole thing into a leadership-ready story
+
+---
+
+## Inference fallback architecture
+
+The AI layer should be treated like any other dependency: it needs routing, degradation, and auditing.
+
+### Routing policy
+
+| Condition | Model path | Notes |
+|---|---|---|
+| private reasoning needed and local LLM healthy | `llm.menezmethod.com` | primary path |
+| local LLM unavailable or above latency threshold | NVIDIA API | fallback path |
+| both models unavailable | deterministic template | no hallucinated analysis |
+
+### Good uses for NVIDIA fallback
+
+- incident summaries
+- failure classification
+- weekly ops brief drafting
+- deploy change summaries
+
+### Bad uses for NVIDIA fallback
+
+- direct infrastructure mutation
+- freeform tool execution
+- authorization decisions
+- hot-path request handling for the public site
+
+### Acceptance criteria
+
+- local-model outage does not block incident reporting
+- fallback use is visible in logs and incident records
+- model outages do not prevent deterministic mitigations
+
+---
+
+## What we should build next
+
+The best next workflow is **`DNS / SSL Guardian`**.
+
+Reasons:
+
+- it matches a real outage you already experienced
+- it is mostly deterministic, which keeps risk low
+- it creates immediate credibility because it solves a painful and believable failure mode
+- it gives us a clean way to demonstrate MCP execution plus structured evidence
+
+After that, move directly to **`Deploy Guardian`** and then **`Inference Router`**.
+
+### Cost Governor Implementation Note
+
+- Added the `Cost Governor` workflow that ingests either the scheduled mock input or webhook payload, normalizes cost/budget telemetry, and emits a structured mitigation ladder without taking destructive action. This workflow keeps a deterministic ladder of observation, constraint, and approval stages so the portfolio can show cost governance coverage while waiting for explicit authorization before enacting changes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ This folder is the single source of truth for that content. The sidebar and inde
 ## Contents
 
 - **Deployment & setup:** `SETUP.md`, `DEPLOY-CLOUDRUN.md`, `CHAT-SECRETS.md`
-- **Operations:** `TRAFFIC-AND-COST.md`, `CI-AND-TESTS.md`, `DEBUGGING-CHAT.md`, `GCP-OBSERVABILITY-MAP.md`
+- **Operations:** `N8N-CONTROL-PLANE.md`, `TRAFFIC-AND-COST.md`, `CI-AND-TESTS.md`, `DEBUGGING-CHAT.md`, `GCP-OBSERVABILITY-MAP.md`
 - **Decisions:** `DECISIONS.md`, `ADMIN-BOARD.md`
 - **Architecture decision records:** `adr/001-*.md`, `adr/002-*.md`, `adr/003-*.md`
 

--- a/ops/n8n/README.md
+++ b/ops/n8n/README.md
@@ -1,0 +1,52 @@
+# n8n Workflow Assets
+
+Versioned workflow imports and helper scripts for the Pi 5 control plane live here.
+
+- `workflows/site-sentinel.json` is the first production-facing control-plane workflow.
+- `workflows/dns-ssl-guardian.json` detects public DNS drift, hostname coverage gaps, and HTTPS failures using public probes plus DNS-over-HTTPS.
+- `workflows/deploy-guardian.json` runs post-deploy smoke checks and packages the outcome for ops review.
+- `workflows/cost-governor.json` models a mitigation ladder and approval guardrail for runaway spend.
+- `workflows/inference-router.json` demonstrates local-first inference with NVIDIA fallback and deterministic final fallback.
+- `scripts/site_sentinel_probe.mjs` is an optional standalone probe helper for out-of-band drills.
+- Import with the n8n CLI from inside the running container.
+- Publish or activate only after a manual execution succeeds.
+
+## Runtime rules
+
+- Use **Code nodes** for shaping data, branching logic, and audit payloads.
+- Use **HTTP Request nodes** for outbound network calls like Slack and NVIDIA. The Pi runtime does not expose `process` or browser-style `fetch` inside the JS task runner.
+- Use `$env` in expressions and Code nodes, not `process.env`.
+- Safe drill mode is enabled with `CONTROL_PLANE_DRILL=1`. That forces monitor workflows to emit notifications without requiring a real outage.
+
+## Current platform constraints
+
+- This n8n instance currently uses **SQLite**, so `n8n execute --id=...` can contend with the live runtime and fail with `SQLITE_BUSY`.
+- Public production webhook URLs for `deploy-guardian` and `cost-governor` are still not registering on this instance even though the workflows activate cleanly.
+- The reliable test path today is:
+  - import the versioned workflow
+  - publish it
+  - activate it
+  - verify activation in container logs
+  - run drills from the UI or migrate the instance to Postgres for cleaner CLI execution
+
+Example import flow:
+
+```bash
+docker cp ops/n8n/workflows/site-sentinel.json menez-n8n-1:/tmp/site-sentinel.json
+docker exec -u node menez-n8n-1 n8n import:workflow --input=/tmp/site-sentinel.json --userId=<USER_ID>
+docker exec -u node menez-n8n-1 n8n publish:workflow --id=<WORKFLOW_ID>
+docker restart menez-n8n-1
+```
+
+Manual test without stopping the running n8n instance:
+
+```bash
+docker exec -u node \
+  -e N8N_RUNNERS_BROKER_PORT=5681 \
+  -e N8N_PORT=5682 \
+  -e CONTROL_PLANE_DRILL=1 \
+  menez-n8n-1 \
+  n8n execute --id=<WORKFLOW_ID>
+```
+
+If you need repeatable CLI drills while the editor stays online, move n8n storage from SQLite to Postgres first.

--- a/ops/n8n/scripts/site_sentinel_probe.mjs
+++ b/ops/n8n/scripts/site_sentinel_probe.mjs
@@ -1,0 +1,76 @@
+const targets = [
+  { name: "homepage", url: "https://gimenez.dev/" },
+  { name: "health_api", url: "https://gimenez.dev/api/health", expectJsonStatus: true },
+  { name: "war_room", url: "https://gimenez.dev/war-room" },
+  { name: "war_room_data", url: "https://gimenez.dev/api/war-room/data" },
+];
+
+const timeoutMs = 8000;
+
+async function probe(target) {
+  const startedAt = Date.now();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(target.url, {
+      method: "GET",
+      redirect: "follow",
+      signal: controller.signal,
+      headers: {
+        "user-agent": "menez-site-sentinel/1.0",
+      },
+    });
+
+    const bodyText = await response.text();
+    let appStatus = null;
+
+    if (target.expectJsonStatus) {
+      try {
+        const parsed = JSON.parse(bodyText);
+        appStatus = parsed.status ?? null;
+      } catch {
+        appStatus = "invalid-json";
+      }
+    }
+
+    return {
+      name: target.name,
+      url: target.url,
+      healthy: response.ok && (!target.expectJsonStatus || appStatus === "healthy"),
+      statusCode: response.status,
+      durationMs: Date.now() - startedAt,
+      appStatus,
+      bodyPreview: bodyText.replace(/\s+/g, " ").slice(0, 160),
+    };
+  } catch (error) {
+    return {
+      name: target.name,
+      url: target.url,
+      healthy: false,
+      statusCode: null,
+      durationMs: Date.now() - startedAt,
+      appStatus: null,
+      error: error?.name === "AbortError" ? `timeout after ${timeoutMs}ms` : String(error?.message || error),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+const checkedAt = new Date().toISOString();
+const results = await Promise.all(targets.map((target) => probe(target)));
+const failures = results.filter((result) => !result.healthy);
+
+console.log(
+  JSON.stringify({
+    workflow: "site-sentinel",
+    checkedAt,
+    status: failures.length > 0 ? "degraded" : "healthy",
+    summary:
+      failures.length > 0
+        ? `${failures.length} failing checks: ${failures.map((failure) => failure.name).join(", ")}`
+        : "all checks healthy",
+    results,
+  }),
+);

--- a/ops/n8n/workflows/cost-governor.json
+++ b/ops/n8n/workflows/cost-governor.json
@@ -1,0 +1,401 @@
+{
+  "id": "6c9b3a95-5eaf-4b40-94a8-35b3d3f1f3c9",
+  "name": "Cost Governor",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "a02cbaf2-3d87-4533-8eb4-0f5b4bbd1c2b",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -960,
+        -320
+      ]
+    },
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "minutes",
+              "minutesInterval": 60
+            }
+          ]
+        }
+      },
+      "id": "c3b1e4d2-8cfe-4f7a-a88a-9a2be0f3b5c1",
+      "name": "Schedule Trigger",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        -960,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "cost-governor",
+        "responseMode": "onReceived",
+        "responseData": "{\"status\":\"accepted\"}",
+        "responseCode": 202,
+        "responseDescription": "Cost Governor evaluation accepted"
+      },
+      "id": "b3f2d1e5-4d30-4a57-aa5e-90b4f3d1c2a4",
+      "name": "Cost Intake Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [
+        -960,
+        160
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const now = new Date().toISOString();\nconst drillMode = $env.CONTROL_PLANE_DRILL === '1';\nreturn [\n  {\n    json: {\n      source: drillMode ? 'manual-drill' : 'scheduled-mock',\n      cost: drillMode ? 44 : 28.3,\n      budget: 40,\n      windowHours: 24,\n      currency: 'USD',\n      timestamp: now,\n      detail: drillMode ? 'Control-plane drill payload for Cost Governor' : 'Scheduled mock input to keep Cost Governor fresh',\n      metadata: {\n        cohort: 'cost-governor-demo',\n        cadence: '60m',\n        drillMode\n      }\n    }\n  }\n];"
+      },
+      "id": "d9a81c5a-21c7-44e5-9b09-7d6f0c2b1a27",
+      "name": "Mock Cost Payload",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -600,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const raw = $input.first().json;\nconst now = new Date().toISOString();\nconst costValue = Number(raw.cost ?? raw.totalCost ?? raw.estimatedCost ?? 0);\nconst budgetValue = Number(raw.budget ?? raw.monthlyBudget ?? raw.allocatedBudget ?? 0);\nconst windowHours = Number(raw.windowHours ?? raw.window ?? 24) || 24;\nconst currency = raw.currency ?? 'USD';\nconst timestamp = raw.timestamp ?? raw.recordedAt ?? now;\nconst source = raw.source ?? 'webhook';\nconst detail = raw.detail ?? raw.notes ?? 'cost telemetry';\nconst metadata = {\n  ...(typeof raw.metadata === 'object' ? raw.metadata : {}),\n  ingestion: source === 'scheduled-mock' ? 'mock' : 'webhook',\n  receivedAt: now\n};\nreturn [{\n  json: {\n    workflow: 'cost-governor',\n    source,\n    timestamp,\n    cost: costValue,\n    budget: budgetValue,\n    windowHours,\n    currency,\n    detail,\n    metadata\n  }\n}];"
+      },
+      "id": "edc3a5f6-1a54-48c2-b7dd-4a5c7b9e8d23",
+      "name": "Normalize Cost Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -240,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const payload = $input.first().json;\nconst cost = Number(payload.cost ?? 0);\nconst budget = Number(payload.budget ?? 0);\nconst windowHours = Math.max(1, Number(payload.windowHours ?? 24));\nconst ratio = budget > 0 ? Number((cost / budget).toFixed(4)) : 0;\nconst hourlyRate = Number((cost / windowHours).toFixed(4));\nconst projected24 = Number((hourlyRate * 24).toFixed(2));\nconst projectedRatio = budget > 0 ? Number((projected24 / budget).toFixed(4)) : null;\nconst shortfall = budget > 0 ? Number((budget - cost).toFixed(2)) : null;\nconst stageDefinitions = [\n  {\n    label: 'Observation',\n    min: 0,\n    max: 0.75,\n    severity: 'nominal',\n    condition: 'ratio < 0.75',\n    rationale: 'Telemetry and War Room continue without intervention.',\n    next: 'Keep watching the War Room and annotate trends for VP reviews.'\n  },\n  {\n    label: 'Constraint',\n    min: 0.75,\n    max: 1,\n    severity: 'warning',\n    condition: '0.75 ≤ ratio < 1.0',\n    rationale: 'Budget trending high; pre-authorize noncritical limits.',\n    next: 'Throttle optional agents, postpone new features, log change request.'\n  },\n  {\n    label: 'Approval Guardrail',\n    min: 1,\n    max: Infinity,\n    severity: 'critical',\n    condition: 'ratio ≥ 1.0',\n    rationale: 'Budget exhausted; manual authorization required before scaling.',\n    next: 'Hold automation, notify approver, and avoid cost-driving actions.'\n  }\n];\nconst activeStage = stageDefinitions.find((stage) => ratio >= stage.min && ratio < stage.max) ?? stageDefinitions[stageDefinitions.length - 1];\nconst mitigationLadder = stageDefinitions.map((stage) => ({\n  stage: stage.label,\n  severity: stage.severity,\n  condition: stage.condition,\n  active: ratio >= stage.min && ratio < stage.max,\n  rationale: stage.rationale,\n  recommendation: stage.next\n}));\nconst requiresApproval = ratio >= 1;\nconst nextAction = requiresApproval ? stageDefinitions[2].next : activeStage.next;\nconst severityLabel = requiresApproval ? 'critical' : ratio >= 0.75 ? 'warning' : 'nominal';\nconst analysisSummary = requiresApproval\n  ? 'Cost governor halted new agents until approval.'\n  : ratio >= 0.75\n    ? 'Preliminary constraints in place; runway thinning.'\n    : 'Budget headroom is healthy.';\nreturn [{\n  json: {\n    ...payload,\n    ratio,\n    hourlyRate,\n    projected24,\n    projectedRatio,\n    shortfall,\n    severity: severityLabel,\n    mitigationLadder,\n    nextAction,\n    requiresApproval,\n    analysisSummary\n  }\n}];"
+      },
+      "id": "f0b2e5c9-3cbf-4202-bec1-1cf1a9b2dcd3",
+      "name": "Assess Mitigation Ladder",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        120,
+        40
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "return [{ json: $input.first().json }];"
+      },
+      "id": "a5d3f4b0-2a31-4a34-afce-0e5b4c4f7a89",
+      "name": "Format Cost Report",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        420,
+        40
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const payload = $input.first().json;\nconst shouldNotify = payload.source !== 'scheduled-mock' || payload.severity !== 'nominal';\nconst icon = payload.severity === 'critical'\n  ? ':rotating_light:'\n  : payload.severity === 'warning'\n    ? ':warning:'\n    : ':white_check_mark:';\nconst lines = [\n  `${icon} *Cost Governor* ${String(payload.severity || 'nominal').toUpperCase()}`,\n  `Source: ${payload.source}`,\n  `Observed: ${payload.cost} ${payload.currency}`,\n  `Budget: ${payload.budget} ${payload.currency}`,\n  `Ratio: ${payload.ratio}`,\n  `Projected 24h: ${payload.projected24} ${payload.currency}`,\n  `Summary: ${payload.analysisSummary}`,\n  `Next action: ${payload.nextAction}`\n];\nreturn [{\n  json: {\n    ...payload,\n    slackNotification: {\n      skip: !shouldNotify,\n      channel: 'C0ALX8C12TG',\n      text: lines.join('\\n')\n    }\n  }\n}];"
+      },
+      "id": "362b1a30-dbd8-4528-a35e-2a1eef4a6cb7",
+      "name": "Build Ops Alert",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        700,
+        40
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "boolean": [
+            {
+              "value1": "={{ $json.slackNotification.skip !== true }}",
+              "value2": true
+            }
+          ]
+        }
+      },
+      "id": "36f8f9ce-a3e0-46f0-9da0-c9a4279dfc14",
+      "name": "Notify Ops?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [
+        940,
+        40
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://slack.com/api/chat.postMessage",
+        "authentication": "none",
+        "sendHeaders": true,
+        "specifyHeaders": "json",
+        "jsonHeaders": "={{ JSON.stringify({ Authorization: 'Bearer ' + $env.SLACK_BOT_TOKEN, 'Content-Type': 'application/json; charset=utf-8' }) }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ channel: $json.slackNotification.channel, text: $json.slackNotification.text }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true,
+              "responseFormat": "json"
+            }
+          },
+          "timeout": 8000
+        }
+      },
+      "id": "f8b38a8c-10b7-4e23-935c-b02f91a95cf2",
+      "name": "Send Ops Slack",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        1180,
+        -80
+      ],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const payload = $input.first().json;\nconst lines = [\n  `:money_with_wings: *Cost Governor Approval Guardrail*`,\n  `Source: ${payload.source}`,\n  `Observed: ${payload.cost} ${payload.currency}`,\n  `Budget: ${payload.budget} ${payload.currency}`,\n  `Ratio: ${payload.ratio}`,\n  `Projected 24h: ${payload.projected24} ${payload.currency}`,\n  `Summary: ${payload.analysisSummary}`,\n  `Action requested: ${payload.nextAction}`\n];\nreturn [{\n  json: {\n    ...payload,\n    approvalNotification: {\n      skip: payload.requiresApproval !== true,\n      channel: 'C0AM2TREPN0',\n      text: lines.join('\\n')\n    }\n  }\n}];"
+      },
+      "id": "d37765c0-a845-43c5-a592-d71b1aab8aae",
+      "name": "Build Approval Alert",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1180,
+        180
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "boolean": [
+            {
+              "value1": "={{ $json.approvalNotification.skip !== true }}",
+              "value2": true
+            }
+          ]
+        }
+      },
+      "id": "88ebc36b-7ec3-4bf0-b225-3680af3f0763",
+      "name": "Notify Approval?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [
+        1420,
+        180
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://slack.com/api/chat.postMessage",
+        "authentication": "none",
+        "sendHeaders": true,
+        "specifyHeaders": "json",
+        "jsonHeaders": "={{ JSON.stringify({ Authorization: 'Bearer ' + $env.SLACK_BOT_TOKEN, 'Content-Type': 'application/json; charset=utf-8' }) }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ channel: $json.approvalNotification.channel, text: $json.approvalNotification.text }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true,
+              "responseFormat": "json"
+            }
+          },
+          "timeout": 8000
+        }
+      },
+      "id": "b37972c3-d791-4cd0-98c0-8311496e6ef0",
+      "name": "Send Approval Slack",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        1660,
+        60
+      ],
+      "continueOnFail": true
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Mock Cost Payload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Schedule Trigger": {
+      "main": [
+        [
+          {
+            "node": "Mock Cost Payload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Cost Intake Webhook": {
+      "main": [
+        [
+          {
+            "node": "Normalize Cost Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Mock Cost Payload": {
+      "main": [
+        [
+          {
+            "node": "Normalize Cost Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Normalize Cost Input": {
+      "main": [
+        [
+          {
+            "node": "Assess Mitigation Ladder",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Assess Mitigation Ladder": {
+      "main": [
+        [
+          {
+            "node": "Format Cost Report",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Cost Report": {
+      "main": [
+        [
+          {
+            "node": "Build Ops Alert",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Ops Alert": {
+      "main": [
+        [
+          {
+            "node": "Notify Ops?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Notify Ops?": {
+      "main": [
+        [
+          {
+            "node": "Send Ops Slack",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ],
+      "main2": [
+        [
+          {
+            "node": "Build Approval Alert",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Ops Slack": {
+      "main": [
+        [
+          {
+            "node": "Build Approval Alert",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Approval Alert": {
+      "main": [
+        [
+          {
+            "node": "Notify Approval?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Notify Approval?": {
+      "main": [
+        [
+          {
+            "node": "Send Approval Slack",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ],
+      "main2": [
+        []
+      ]
+    },
+    "Send Approval Slack": {
+      "main": [
+        []
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "meta": null,
+  "versionId": "cbbde6a5-d543-4e6d-b844-9bddc7b9d2a7"
+}

--- a/ops/n8n/workflows/deploy-guardian.json
+++ b/ops/n8n/workflows/deploy-guardian.json
@@ -1,0 +1,385 @@
+{
+  "id": "c2f3f6c0-8134-4a05-9c09-22d8d5f27a69",
+  "name": "Deploy Guardian",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "d7f9bdde-9b89-4d6b-96bb-5f41c9c4ab12",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -1100,
+        -150
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "return [{ json: { triggerSource: 'manual', triggerLabel: 'Manual run' } }];"
+      },
+      "id": "21882f85-c0f4-4f66-9a20-ded3ebd3c4a2",
+      "name": "Label Manual Run",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -840,
+        -170
+      ]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "deploy-guardian",
+        "responseMode": "onReceived",
+        "responseData": "{\"status\":\"accepted\"}",
+        "responseContentType": "application/json",
+        "options": {}
+      },
+      "id": "2c485890-ef6f-4f6a-bc52-c70b1b82d0df",
+      "name": "Deploy Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [
+        -1100,
+        120
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const incoming = $input.first().json ?? {};\nreturn [{\n  json: {\n    triggerSource: 'webhook',\n    triggerLabel: 'Deploy webhook',\n    deploymentId: incoming.deployment_id ?? incoming.deploy_id ?? incoming.deployment?.id ?? incoming.sha ?? null,\n    deploymentMeta: {\n      branch: incoming.branch ?? incoming.ref ?? null,\n      sha: incoming.sha ?? incoming.commit ?? null,\n      status: incoming.status ?? incoming.state ?? null,\n      raw: incoming\n    }\n  }\n}];"
+      },
+      "id": "52f0a1a2-75c4-4df3-8ad9-e3f10c1f5e86",
+      "name": "Label Webhook",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -840,
+        120
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "passThrough",
+        "mergeBy": "allEntries"
+      },
+      "id": "5c7ffbc5-803c-4fc1-9dd2-3c7c7f624af3",
+      "name": "Merge Sources",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 1,
+      "position": [
+        -560,
+        -20
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const sourceItem = $input.first()?.json ?? {};\nconst triggerSource = sourceItem.triggerSource ?? 'manual';\nconst triggerLabel = sourceItem.triggerLabel ?? (triggerSource === 'webhook' ? 'Deploy webhook' : 'Manual run');\nconst deploymentMeta = sourceItem.deploymentMeta ?? {};\nconst targets = [\n  { name: 'homepage', url: 'https://gimenez.dev/', expectJsonStatus: false },\n  { name: 'health_api', url: 'https://gimenez.dev/api/health', expectJsonStatus: true },\n  { name: 'war_room', url: 'https://gimenez.dev/war-room', expectJsonStatus: false },\n  { name: 'war_room_data', url: 'https://gimenez.dev/api/war-room/data', expectJsonStatus: false },\n  { name: 'chat_page', url: 'https://gimenez.dev/chat', expectJsonStatus: false }\n];\n\nreturn targets.map((target, index) => ({\n  json: {\n    ...target,\n    triggerSource,\n    triggerLabel,\n    deploymentMeta,\n    checkId: index + 1,\n    workflow: 'deploy-guardian'\n  }\n}));"
+      },
+      "id": "b5c9d1f9-a8b3-47c2-9cb5-6d1e59f4f6d4",
+      "name": "Build Targets",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -360,
+        -20
+      ]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $json.url }}",
+        "authentication": "none",
+        "options": {
+          "redirect": {
+            "redirect": {
+              "followRedirects": true,
+              "maxRedirects": 5
+            }
+          },
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true,
+              "responseFormat": "text",
+              "outputPropertyName": "body"
+            }
+          },
+          "timeout": 8000
+        }
+      },
+      "id": "8f12f5d8-76a5-46cc-a4e0-df6b7f4f4f23",
+      "name": "Probe Targets",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        -120,
+        -20
+      ],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const workflowStaticData = $getWorkflowStaticData('global');\nconst checkedAt = new Date().toISOString();\nconst inputItems = $input.all();\nconst sourceItem = inputItems.find((item) => item.json.triggerSource) ?? inputItems[0] ?? {};\nconst triggerSource = sourceItem.json?.triggerSource ?? 'manual';\nconst triggerLabel = sourceItem.json?.triggerLabel ?? (triggerSource === 'webhook' ? 'Deploy webhook' : 'Manual run');\nconst deploymentMeta = sourceItem.json?.deploymentMeta ?? {};\n\nconst results = inputItems.map((item) => {\n  const target = {\n    name: item.json.name ?? `unknown-${item.pairedItem?.item ?? 0}`,\n    url: item.json.url ?? null,\n    expectJsonStatus: item.json.expectJsonStatus ?? false\n  };\n  const bodyText = String(item.json.body ?? '');\n  let appStatus = null;\n\n  if (target.expectJsonStatus) {\n    try {\n      const parsed = JSON.parse(bodyText);\n      appStatus = parsed.status ?? null;\n    } catch (error) {\n      appStatus = bodyText ? 'invalid-json' : null;\n    }\n  }\n\n  const statusCode = Number(item.json.statusCode ?? 0);\n  const healthy = !item.json.error && statusCode >= 200 && statusCode < 400 && (!target.expectJsonStatus || appStatus === 'healthy');\n\n  return {\n    name: target.name,\n    url: target.url,\n    healthy,\n    statusCode: statusCode || null,\n    statusMessage: item.json.statusMessage ?? null,\n    appStatus,\n    error: item.json.error ?? null,\n    proxyLatencyMs: item.json.duration ?? null,\n    checksum: target.expectJsonStatus ? appStatus : null\n  };\n});\n\nconst failures = results.filter((result) => !result.healthy);\nconst previousFailures = Number(workflowStaticData.deployGuardianFailures || 0);\nconst consecutiveFailures = failures.length > 0 ? previousFailures + 1 : 0;\nconst shouldEscalate = failures.length > 0 && consecutiveFailures >= 2;\n\nworkflowStaticData.deployGuardianFailures = consecutiveFailures;\nworkflowStaticData.lastDeployGuardianCheck = checkedAt;\nworkflowStaticData.lastDeployStatus = failures.length > 0 ? (shouldEscalate ? 'incident' : 'degraded') : 'healthy';\n\nconst summary = failures.length > 0\n  ? `${failures.length} failing smoke checks: ${failures.map((result) => result.name).join(', ')}`\n  : 'all smoke checks successful';\n\nreturn [\n  {\n    json: {\n      workflow: 'deploy-guardian',\n      checkedAt,\n      triggerSource,\n      triggerLabel,\n      deploymentMeta,\n      status: failures.length > 0 ? (shouldEscalate ? 'incident' : 'degraded') : 'healthy',\n      shouldEscalate,\n      consecutiveFailures,\n      summary,\n      results\n    }\n  }\n];"
+      },
+      "id": "74a4e3d9-b8f0-45b4-8f43-ec623d0b2d95",
+      "name": "Evaluate Results",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        120,
+        -20
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const payload = $input.first().json;\nreturn [{ json: { ...payload, reportVersion: 'deploy-guardian.v1', finalizedAt: new Date().toISOString() } }];"
+      },
+      "id": "b4c24b1a-5be7-4b7a-9d77-bb1a8f72d4b7",
+      "name": "Formal Summary",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        340,
+        -20
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const payload = $input.first().json;\nconst failingChecks = (payload.results || []).filter((check) => !check.healthy).map((check) => check.name);\nconst icon = payload.status === 'healthy'\n  ? ':white_check_mark:'\n  : payload.status === 'degraded'\n    ? ':warning:'\n    : ':rotating_light:';\nconst lines = [\n  `${icon} *Deploy Guardian* ${String(payload.status || 'unknown').toUpperCase()}`,\n  `Run: ${payload.triggerLabel || payload.triggerSource || 'manual'}`,\n  `Checked: ${payload.checkedAt}`,\n  `Summary: ${payload.summary}`\n];\nif (payload.deploymentMeta?.sha) {\n  lines.push(`SHA: ${payload.deploymentMeta.sha}`);\n}\nif (failingChecks.length > 0) {\n  lines.push(`Failing checks: ${failingChecks.join(', ')}`);\n}\nreturn [\n  {\n    json: {\n      ...payload,\n      slackNotification: {\n        skip: false,\n        channel: 'C0ALX8C12TG',\n        text: lines.join('\\n')\n      }\n    }\n  }\n];"
+      },
+      "id": "a3a3f1d6-6394-4a39-9244-411f4a6fbf08",
+      "name": "Build Ops Alert",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        620,
+        -20
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "boolean": [
+            {
+              "value1": "={{ $json.slackNotification.skip !== true }}",
+              "value2": true
+            }
+          ]
+        }
+      },
+      "id": "e5aa37c0-cf5a-4f96-a4ce-a70737ea6d53",
+      "name": "Notify Ops?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [
+        860,
+        -20
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://slack.com/api/chat.postMessage",
+        "authentication": "none",
+        "sendHeaders": true,
+        "specifyHeaders": "json",
+        "jsonHeaders": "={{ JSON.stringify({ Authorization: 'Bearer ' + $env.SLACK_BOT_TOKEN, 'Content-Type': 'application/json; charset=utf-8' }) }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ channel: $json.slackNotification.channel, text: $json.slackNotification.text }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true,
+              "responseFormat": "json"
+            }
+          },
+          "timeout": 8000
+        }
+      },
+      "id": "6b69bcb7-324f-4fd0-a717-739276f17752",
+      "name": "Send Ops Slack",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        1100,
+        -140
+      ],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "jsCode": "const payload = $input.first().json;\nif (!payload.shouldEscalate) {\n  return [{ json: { ...payload, escalated: false } }];\n}\nconst failing = payload.results?.filter((check) => !check.healthy) ?? [];\nthrow new Error(JSON.stringify({\n  workflow: payload.workflow,\n  status: payload.status,\n  summary: payload.summary,\n  consecutiveFailures: payload.consecutiveFailures,\n  deploymentMeta: payload.deploymentMeta,\n  failingChecks: failing\n}));"
+      },
+      "id": "1165a8c6-1e2b-4df5-8a1b-8b9f7e1c1d0e",
+      "name": "Escalate Incident",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1320,
+        120
+      ],
+      "continueOnFail": true
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Label Manual Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Label Manual Run": {
+      "main": [
+        [
+          {
+            "node": "Merge Sources",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Deploy Webhook": {
+      "main": [
+        [
+          {
+            "node": "Label Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Label Webhook": {
+      "main": [
+        [
+          {
+            "node": "Merge Sources",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge Sources": {
+      "main": [
+        [
+          {
+            "node": "Build Targets",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Targets": {
+      "main": [
+        [
+          {
+            "node": "Probe Targets",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Probe Targets": {
+      "main": [
+        [
+          {
+            "node": "Evaluate Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Evaluate Results": {
+      "main": [
+        [
+          {
+            "node": "Formal Summary",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Formal Summary": {
+      "main": [
+        [
+          {
+            "node": "Build Ops Alert",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Ops Alert": {
+      "main": [
+        [
+          {
+            "node": "Notify Ops?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Notify Ops?": {
+      "main": [
+        [
+          {
+            "node": "Send Ops Slack",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ],
+      "main2": [
+        [
+          {
+            "node": "Escalate Incident",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Ops Slack": {
+      "main": [
+        [
+          {
+            "node": "Escalate Incident",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Escalate Incident": {
+      "main": []
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "meta": null,
+  "versionId": "14c3c0a5-2dfb-4d62-9a83-c4ec9451dbef"
+}

--- a/ops/n8n/workflows/dns-ssl-guardian.json
+++ b/ops/n8n/workflows/dns-ssl-guardian.json
@@ -1,0 +1,478 @@
+{
+  "id": "1fd0b80a-0d76-40d3-aaf9-542ea89eb687",
+  "name": "DNS / SSL Guardian",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "f9a2ad41-eaf0-4383-95dc-36ebacb7d849",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -1160,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "triggerSource",
+              "value": "manual"
+            },
+            {
+              "name": "triggerLabel",
+              "value": "Manual run"
+            }
+          ]
+        },
+        "options": {
+          "keepOnlySet": false
+        }
+      },
+      "id": "87d9986f-a2d2-45a0-9fa5-f6b7abf4a12b",
+      "name": "Label Manual Run",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [
+        -960,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "minutes",
+              "minutesInterval": 30
+            }
+          ]
+        }
+      },
+      "id": "eb6d2d77-5fa2-4e32-84b0-557fa7eb09bf",
+      "name": "Schedule Trigger",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        -1160,
+        120
+      ]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "triggerSource",
+              "value": "scheduled"
+            },
+            {
+              "name": "triggerLabel",
+              "value": "Scheduled run"
+            }
+          ]
+        },
+        "options": {
+          "keepOnlySet": false
+        }
+      },
+      "id": "57b1cb16-fdb4-40b1-b40a-22f57120d0cb",
+      "name": "Label Scheduled Run",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [
+        -960,
+        120
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "passThrough",
+        "mergeBy": "allEntries"
+      },
+      "id": "3ccd7576-b52a-4580-9588-f406276bd76b",
+      "name": "Merge Sources",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 1,
+      "position": [
+        -840,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const sourceItem = $input.first()?.json ?? {};\nconst triggerSource = sourceItem.triggerSource ?? 'manual';\nconst triggerLabel = sourceItem.triggerLabel ?? 'Manual run';\nreturn [\n  { json: { name: 'apex_http', url: 'http://gimenez.dev/', scheme: 'http', triggerSource, triggerLabel } },\n  { json: { name: 'apex_https', url: 'https://gimenez.dev/', scheme: 'https', triggerSource, triggerLabel } },\n  { json: { name: 'www_https', url: 'https://www.gimenez.dev/', scheme: 'https', triggerSource, triggerLabel } }\n];"
+      },
+      "id": "96c35fc5-bad0-4906-bbbb-35e41684548a",
+      "name": "Build Endpoint Targets",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -620,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $json.url }}",
+        "authentication": "none",
+        "options": {
+          "redirect": {
+            "redirect": {
+              "followRedirects": true,
+              "maxRedirects": 5
+            }
+          },
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true,
+              "responseFormat": "text",
+              "outputPropertyName": "body"
+            }
+          },
+          "timeout": 8000
+        }
+      },
+      "id": "3e62df1c-f1f0-4c4b-a3d0-ecb77cb72b24",
+      "name": "Probe Public Endpoints",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        -360,
+        0
+      ],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const checkedAt = new Date().toISOString();\nconst targets = $('Build Endpoint Targets').all().map((item) => item.json);\nconst inputs = $input.all();\nconst triggerSource = inputs[0]?.json?.triggerSource ?? 'scheduled';\nconst triggerLabel = inputs[0]?.json?.triggerLabel ?? (triggerSource === 'manual' ? 'Manual run' : 'Scheduled run');\n\nconst publicEndpoints = inputs.map((item, index) => {\n  const targetIndex = item.pairedItem?.item ?? index;\n  const target = targets[targetIndex] || targets[0];\n  const bodyText = String(item.json.body || '');\n  const locationHeader = item.json.headers?.location || item.json.headers?.Location || null;\n  const statusCode = Number(item.json.statusCode || 0);\n  const healthy = !item.json.error && statusCode >= 200 && statusCode < 400;\n\n  return {\n    name: target.name,\n    url: target.url,\n    scheme: target.scheme,\n    healthy,\n    statusCode: item.json.statusCode ?? null,\n    statusMessage: item.json.statusMessage ?? null,\n    location: locationHeader,\n    error: item.json.error ?? null,\n    bodyPreview: bodyText.slice(0, 160)\n  };\n});\n\nconst endpointMap = Object.fromEntries(publicEndpoints.map((result) => [result.name, result]));\n\nreturn [\n  {\n    json: {\n      workflow: 'dns-ssl-guardian',\n      checkedAt,\n      triggerSource,\n      triggerLabel,\n      publicEndpoints,\n      publicStatus: {\n        apexHttpHealthy: Boolean(endpointMap.apex_http?.healthy),\n        apexHttpsHealthy: Boolean(endpointMap.apex_https?.healthy),\n        wwwHttpsHealthy: Boolean(endpointMap.www_https?.healthy)\n      }\n    }\n  }\n];"
+      },
+      "id": "cab37555-4958-48fd-a78a-fca72c4f32e6",
+      "name": "Evaluate Endpoint Results",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -100,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "return [\n  { json: { label: 'google_apex_a', resolver: 'google', endpoint: 'https://dns.google/resolve', query: { name: 'gimenez.dev', type: 'A' }, headers: {} } },\n  { json: { label: 'google_www_cname', resolver: 'google', endpoint: 'https://dns.google/resolve', query: { name: 'www.gimenez.dev', type: 'CNAME' }, headers: {} } },\n  { json: { label: 'cloudflare_apex_a', resolver: 'cloudflare', endpoint: 'https://cloudflare-dns.com/dns-query', query: { name: 'gimenez.dev', type: 'A' }, headers: { accept: 'application/dns-json' } } },\n  { json: { label: 'cloudflare_www_cname', resolver: 'cloudflare', endpoint: 'https://cloudflare-dns.com/dns-query', query: { name: 'www.gimenez.dev', type: 'CNAME' }, headers: { accept: 'application/dns-json' } } } \n];"
+      },
+      "id": "7a055df5-9d76-4c2c-bd27-4fb124d51fe3",
+      "name": "Build DNS Queries",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        140,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $json.endpoint }}",
+        "authentication": "none",
+        "sendQuery": true,
+        "specifyQuery": "json",
+        "jsonQuery": "={{ JSON.stringify($json.query) }}",
+        "sendHeaders": true,
+        "specifyHeaders": "json",
+        "jsonHeaders": "={{ JSON.stringify($json.headers || {}) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true,
+              "responseFormat": "json"
+            }
+          },
+          "timeout": 8000
+        }
+      },
+      "id": "f9db3da4-7cf8-4f1b-b4c9-5ef4e99f5d2e",
+      "name": "Query Public DNS",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        420,
+        0
+      ],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const workflowStaticData = $getWorkflowStaticData('global');\nconst base = $('Evaluate Endpoint Results').first().json;\nconst queryItems = $('Build DNS Queries').all().map((item) => item.json);\n\nconst dnsResponses = $input.all().map((item, index) => {\n  const queryIndex = item.pairedItem?.item ?? index;\n  const queryItem = queryItems[queryIndex] || queryItems[0];\n  const query = queryItem?.query || {};\n  const body = item.json.body || {};\n  const answers = Array.isArray(body.Answer) ? body.Answer : [];\n\n  return {\n    label: queryItem?.label || null,\n    resolver: queryItem?.resolver || null,\n    endpoint: queryItem?.endpoint || null,\n    query,\n    statusCode: item.json.statusCode ?? null,\n    statusMessage: item.json.statusMessage ?? null,\n    error: item.json.error ?? null,\n    answers: answers.map((answer) => String(answer.data || '').replace(/\\.$/, '').toLowerCase())\n  };\n});\n\nconst apexRecordsByResolver = Object.fromEntries(\n  dnsResponses\n    .filter((response) => response.query.name === 'gimenez.dev')\n    .map((response) => [response.resolver, response.answers])\n);\nconst wwwTargetsByResolver = Object.fromEntries(\n  dnsResponses\n    .filter((response) => response.query.name === 'www.gimenez.dev')\n    .map((response) => [response.resolver, response.answers])\n);\n\nconst apexResolverAnswers = Object.values(apexRecordsByResolver);\nconst wwwResolverAnswers = Object.values(wwwTargetsByResolver);\nconst apexUnique = [...new Set(apexResolverAnswers.flat())];\nconst dnsConsistent = apexResolverAnswers.length > 0 && apexResolverAnswers.every((answers) => answers.length > 0) && apexUnique.length === 1;\nconst wwwPointsToApex = wwwResolverAnswers.length > 0 && wwwResolverAnswers.every((answers) => answers.length > 0 && answers.includes('gimenez.dev'));\n\nconst findings = [];\nconst recommendedActions = [];\n\nif (!dnsConsistent) {\n  findings.push('dns_inconsistent_public_resolvers');\n  recommendedActions.push('Compare public DNS answers with the registrar and edge configuration.');\n}\n\nif (!wwwPointsToApex) {\n  findings.push('www_cname_mismatch');\n  recommendedActions.push('Ensure the www CNAME points to gimenez.dev.');\n}\n\nif (base.publicStatus.apexHttpHealthy && !base.publicStatus.apexHttpsHealthy) {\n  findings.push('https_failing_while_http_reachable');\n  recommendedActions.push('Check TLS and Google-managed certificate health before changing DNS.');\n}\n\nif (base.publicStatus.apexHttpsHealthy && !base.publicStatus.wwwHttpsHealthy) {\n  findings.push('www_hostname_coverage_gap');\n  recommendedActions.push('Verify the edge certificate covers both apex and www hostnames.');\n}\n\nif (!base.publicStatus.apexHttpHealthy && !base.publicStatus.apexHttpsHealthy && dnsConsistent) {\n  findings.push('origin_or_edge_unreachable');\n  recommendedActions.push('Inspect edge routing and Cloud Run reachability from GCP.');\n}\n\nconst previousFailures = Number(workflowStaticData.consecutiveFailures || 0);\nconst consecutiveFailures = findings.length > 0 ? previousFailures + 1 : 0;\nconst shouldEscalate = findings.length > 0 && consecutiveFailures >= 2;\nconst summary = findings.length > 0 ? findings.join(', ') : 'dns and tls checks healthy';\n\nworkflowStaticData.lastCheckedAt = base.checkedAt;\nworkflowStaticData.lastSummary = summary;\nworkflowStaticData.consecutiveFailures = consecutiveFailures;\nworkflowStaticData.lastStatus = findings.length > 0 ? 'degraded' : 'healthy';\n\nreturn [\n  {\n    json: {\n      workflow: 'dns-ssl-guardian',\n      checkedAt: base.checkedAt,\n      triggerSource: base.triggerSource,\n      triggerLabel: base.triggerLabel,\n      status: findings.length > 0 ? (shouldEscalate ? 'incident' : 'degraded') : 'healthy',\n      shouldEscalate,\n      consecutiveFailures,\n      summary,\n      findings,\n      recommendedActions,\n      publicEndpoints: base.publicEndpoints,\n      dnsState: {\n        dnsConsistent,\n        apexRecordsByResolver,\n        apexUnique,\n        wwwTargetsByResolver,\n        wwwPointsToApex\n      },\n      dnsResponses\n    }\n  }\n];"
+      },
+      "id": "cb748939-e18d-44d0-978f-5d53c95532d5",
+      "name": "Evaluate DNS Results",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        700,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const payload = $input.first().json;\nconst drillMode = $env.CONTROL_PLANE_DRILL === '1';\nconst shouldNotify = drillMode || payload.triggerSource === 'manual' || payload.status !== 'healthy';\nconst icon = payload.status === 'healthy'\n  ? ':white_check_mark:'\n  : payload.status === 'degraded'\n    ? ':warning:'\n    : ':rotating_light:';\nconst lines = [\n  `${icon} *DNS / SSL Guardian* ${String(payload.status || 'unknown').toUpperCase()}`,\n  `Run: ${payload.triggerLabel || payload.triggerSource || 'manual'}`,\n  `Checked: ${payload.checkedAt}`,\n  `Summary: ${payload.summary}`\n];\nif (drillMode) {\n  lines.push('Mode: control-plane drill');\n}\nif ((payload.findings || []).length > 0) {\n  lines.push(`Findings: ${payload.findings.join(', ')}`);\n}\nif ((payload.recommendedActions || []).length > 0) {\n  lines.push(`Next steps: ${payload.recommendedActions.join(' | ')}`);\n}\nreturn [\n  {\n    json: {\n      ...payload,\n      slackNotification: {\n        skip: !shouldNotify,\n        channel: 'C0ALX8C12TG',\n        text: lines.join('\\n')\n      }\n    }\n  }\n];"
+      },
+      "id": "ee545929-1cf1-4a0b-8fab-f25b0fc91d09",
+      "name": "Build Ops Alert",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        960,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "boolean": [
+            {
+              "value1": "={{ $json.slackNotification.skip !== true }}",
+              "value2": true
+            }
+          ]
+        }
+      },
+      "id": "7c892bd1-72e3-4c21-bdfa-62372ad5fe2b",
+      "name": "Notify Ops?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [
+        1180,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://slack.com/api/chat.postMessage",
+        "authentication": "none",
+        "sendHeaders": true,
+        "specifyHeaders": "json",
+        "jsonHeaders": "={{ JSON.stringify({ Authorization: 'Bearer ' + $env.SLACK_BOT_TOKEN, 'Content-Type': 'application/json; charset=utf-8' }) }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ channel: $json.slackNotification.channel, text: $json.slackNotification.text }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true,
+              "responseFormat": "json"
+            }
+          },
+          "timeout": 8000
+        }
+      },
+      "id": "624ae5ed-e761-478f-afc0-4a60b97c70bb",
+      "name": "Send Ops Slack",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        1420,
+        -120
+      ],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const payload = $input.first().json;\n\nif (!payload.shouldEscalate) {\n  return [{ json: payload }];\n}\n\nthrow new Error(JSON.stringify({\n  workflow: payload.workflow,\n  checkedAt: payload.checkedAt,\n  consecutiveFailures: payload.consecutiveFailures,\n  summary: payload.summary,\n  findings: payload.findings,\n  recommendedActions: payload.recommendedActions\n}));"
+      },
+      "id": "bb1e22e8-9d63-4f65-8f26-8d7a0c78de55",
+      "name": "Escalate Incident",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1640,
+        0
+      ]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Label Manual Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Schedule Trigger": {
+      "main": [
+        [
+          {
+            "node": "Label Scheduled Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Label Manual Run": {
+      "main": [
+        [
+          {
+            "node": "Merge Sources",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Label Scheduled Run": {
+      "main": [
+        [
+          {
+            "node": "Merge Sources",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge Sources": {
+      "main": [
+        [
+          {
+            "node": "Build Endpoint Targets",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Endpoint Targets": {
+      "main": [
+        [
+          {
+            "node": "Probe Public Endpoints",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Probe Public Endpoints": {
+      "main": [
+        [
+          {
+            "node": "Evaluate Endpoint Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Evaluate Endpoint Results": {
+      "main": [
+        [
+          {
+            "node": "Build DNS Queries",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build DNS Queries": {
+      "main": [
+        [
+          {
+            "node": "Query Public DNS",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Query Public DNS": {
+      "main": [
+        [
+          {
+            "node": "Evaluate DNS Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Evaluate DNS Results": {
+      "main": [
+        [
+          {
+            "node": "Build Ops Alert",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Ops Alert": {
+      "main": [
+        [
+          {
+            "node": "Notify Ops?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Notify Ops?": {
+      "main": [
+        [
+          {
+            "node": "Send Ops Slack",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ],
+      "main2": [
+        [
+          {
+            "node": "Escalate Incident",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Ops Slack": {
+      "main": [
+        [
+          {
+            "node": "Escalate Incident",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "meta": null,
+  "versionId": "e7527cba-6aa1-4fc0-a598-9e772f0f8db1"
+}

--- a/ops/n8n/workflows/inference-router.json
+++ b/ops/n8n/workflows/inference-router.json
@@ -1,0 +1,444 @@
+{
+  "id": "f1a2d4b5-3c22-48d4-8b26-0f8b0629c8b3",
+  "name": "Inference Router",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "04b0f2cd-9641-4f61-b115-5f1be0c1222f",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -800,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const prompt = 'System prompt placeholder to demonstrate the router flow for testing.';\nconst sessionId = 'demo-session';\nreturn [{\n  json: {\n    request: {\n      prompt,\n      sessionId,\n      metadata: {\n        source: 'ops/n8n',\n        requestedAt: new Date().toISOString()\n      }\n    },\n    attempts: [],\n    prompt,\n    sessionId,\n    workflow: 'inference-router'\n  }\n}];"
+      },
+      "id": "c7d03a2c-5e0f-4b6f-a32e-8b4c9d895f6e",
+      "name": "Build Request",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -560,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.LOCAL_LLM_ENDPOINT || 'http://localhost:8080/api/chat/local' }}",
+        "authentication": "none",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.request) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true,
+              "responseFormat": "json",
+              "outputPropertyName": "body"
+            }
+          },
+          "timeout": 12000
+        }
+      },
+      "id": "d9ba6057-3207-4b6f-b9a0-dc5a17d34bbd",
+      "name": "Local LLM",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        -320,
+        0
+      ],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "functionCode": "const requestMeta = $node['Build Request'].json;\nconst response = $input.item.json;\nconst envelope = response?.body ?? response;\nconst statusCode = envelope?.statusCode ?? response?.statusCode ?? null;\nconst success = typeof statusCode === 'number' ? statusCode >= 200 && statusCode < 400 && !response?.error : false;\nconst attempts = [...(requestMeta.attempts || [])];\nattempts.push({\n  step: 'local',\n  success,\n  statusCode,\n  error: response?.error ?? null,\n  reason: success ? 'handled locally' : 'local-call-failed',\n  timestamp: new Date().toISOString()\n});\nconst payload = envelope?.body ?? envelope?.data ?? null;\nreturn [{\n  json: {\n    request: requestMeta.request,\n    prompt: requestMeta.prompt,\n    sessionId: requestMeta.sessionId,\n    attempts,\n    success,\n    localResponse: payload,\n    statusCode,\n    lastStep: 'local'\n  }\n}];"
+      },
+      "id": "4e3f1b16-f99d-4c9a-8a64-3b3e2b6129ab",
+      "name": "Audit Local",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        -80,
+        -80
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "boolean": [
+            {
+              "value1": "={{ $json.success === true }}",
+              "value2": true
+            }
+          ]
+        }
+      },
+      "id": "9a2d0e2a-8b2b-4b71-aedf-bd13680d85d5",
+      "name": "Local Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [
+        120,
+        -80
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const payload = $input.first().json;\nreturn [{\n  json: {\n    decision: 'local',\n    payload: payload.localResponse,\n    fallbackAudit: payload.attempts,\n    metadata: {\n      prompt: payload.prompt,\n      sessionId: payload.sessionId,\n      statusCode: payload.statusCode,\n      path: 'local'\n    }\n  }\n}];"
+      },
+      "id": "f492b1a0-dcf0-4d55-a53d-97d0519cfd2e",
+      "name": "Compile Local",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        360,
+        -160
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://integrate.api.nvidia.com/v1/chat/completions",
+        "authentication": "none",
+        "sendHeaders": true,
+        "specifyHeaders": "json",
+        "jsonHeaders": "={{ JSON.stringify({ Authorization: 'Bearer ' + $env.NVIDIA_API_KEY, 'Content-Type': 'application/json' }) }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'moonshotai/kimi-k2.5', messages: [{ role: 'user', content: $json.prompt }], max_tokens: 16384, temperature: 1, top_p: 1, stream: false }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true,
+              "responseFormat": "json",
+              "outputPropertyName": "body"
+            }
+          },
+          "timeout": 20000
+        }
+      },
+      "id": "5aac4a2f-974d-40c8-9710-08b0a7551baf",
+      "name": "NVIDIA Call",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        120,
+        80
+      ],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "functionCode": "const prior = $node['Audit Local'].json;\nconst response = $input.item.json;\nconst envelope = response?.body ?? response;\nconst statusCode = envelope?.statusCode ?? response?.statusCode ?? null;\nconst success = typeof statusCode === 'number' ? statusCode >= 200 && statusCode < 400 && !response?.error : false;\nconst attempts = [...(prior.attempts || [])];\nattempts.push({\n  step: 'nvidia',\n  success,\n  statusCode,\n  error: response?.error ?? null,\n  reason: success ? 'nvidia-fallback' : 'nvidia-call-failed',\n  timestamp: new Date().toISOString()\n});\nconst payload = envelope?.body?.choices?.[0]?.message?.content ?? envelope?.body ?? envelope?.data ?? null;\nreturn [{\n  json: {\n    request: prior.request,\n    prompt: prior.prompt,\n    sessionId: prior.sessionId,\n    attempts,\n    success,\n    nvidiaResponse: payload,\n    statusCode,\n    lastStep: 'nvidia'\n  }\n}];"
+      },
+      "id": "c6ba90cf-3c8b-4f12-b383-246a6daa2d7d",
+      "name": "Audit NVIDIA",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        360,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "boolean": [
+            {
+              "value1": "={{ $json.success === true }}",
+              "value2": true
+            }
+          ]
+        }
+      },
+      "id": "376dce3e-0e50-4ffa-b44b-0c0c5df4b3b9",
+      "name": "NVIDIA Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [
+        600,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const nodeData = $input.item.json;\nreturn [{ json: { decision: 'nvidia', payload: nodeData.nvidiaResponse, fallbackAudit: nodeData.attempts, metadata: { prompt: nodeData.prompt, sessionId: nodeData.sessionId, statusCode: nodeData.statusCode, path: nodeData.lastStep } } }];"
+      },
+      "id": "4b61501e-8588-4b65-b3e6-295c30a1b5ca",
+      "name": "Compile NVIDIA",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        840,
+        -80
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const nodeData = $input.item.json;\nconst deterministicAnswer = `Deterministic fallback for \"${nodeData.prompt}\" while remote services recover.`;\nconst attempts = [...(nodeData.attempts || [])];\nattempts.push({\n  step: 'deterministic',\n  success: true,\n  statusCode: 200,\n  reason: 'deterministic-answer',\n  timestamp: new Date().toISOString()\n});\nreturn [{ json: { decision: 'deterministic', payload: deterministicAnswer, fallbackAudit: attempts, metadata: { prompt: nodeData.prompt, sessionId: nodeData.sessionId, statusCode: 200, path: 'deterministic' } } }];"
+      },
+      "id": "be7f8b4a-5d7c-448b-b8d1-6aedba1e9d7a",
+      "name": "Deterministic Fallback",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [
+        840,
+        140
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const payload = $input.first().json;\nconst attempts = Array.isArray(payload.fallbackAudit) ? payload.fallbackAudit : [];\nconst icon = payload.decision === 'local'\n  ? ':white_check_mark:'\n  : payload.decision === 'nvidia'\n    ? ':satellite:'\n    : ':warning:';\nconst lines = [\n  `${icon} *Inference Router* ${String(payload.decision || 'unknown').toUpperCase()}`,\n  `Session: ${payload.metadata?.sessionId || 'unknown'}`,\n  `Path: ${payload.metadata?.path || payload.decision}`,\n  `Status: ${payload.metadata?.statusCode || 'n/a'}`,\n  `Attempts: ${attempts.map((attempt) => `${attempt.step}:${attempt.success ? 'ok' : 'fail'}`).join(', ') || 'none'}`\n];\nreturn [{\n  json: {\n    ...payload,\n    slackNotification: {\n      skip: false,\n      channel: 'C0ALX8C12TG',\n      text: lines.join('\\n')\n    }\n  }\n}];"
+      },
+      "id": "b5bbf5fc-614b-4478-baf4-27b6dd4c1c87",
+      "name": "Build Ops Alert",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1120,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "boolean": [
+            {
+              "value1": "={{ $json.slackNotification.skip !== true }}",
+              "value2": true
+            }
+          ]
+        }
+      },
+      "id": "1e9ae661-3ae0-4b74-8f8c-98f159f01bf4",
+      "name": "Notify Ops?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [
+        1360,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://slack.com/api/chat.postMessage",
+        "authentication": "none",
+        "sendHeaders": true,
+        "specifyHeaders": "json",
+        "jsonHeaders": "={{ JSON.stringify({ Authorization: 'Bearer ' + $env.SLACK_BOT_TOKEN, 'Content-Type': 'application/json; charset=utf-8' }) }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ channel: $json.slackNotification.channel, text: $json.slackNotification.text }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true,
+              "responseFormat": "json"
+            }
+          },
+          "timeout": 8000
+        }
+      },
+      "id": "f6d83b7d-d7a7-4a84-b5a5-bbcab30fba1e",
+      "name": "Send Ops Slack",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        1600,
+        -120
+      ],
+      "continueOnFail": true
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Build Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Request": {
+      "main": [
+        [
+          {
+            "node": "Local LLM",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Local LLM": {
+      "main": [
+        [
+          {
+            "node": "Audit Local",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Audit Local": {
+      "main": [
+        [
+          {
+            "node": "Local Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Local Success?": {
+      "main": [
+        [
+          {
+            "node": "Compile Local",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ],
+      "main2": [
+        [
+          {
+            "node": "NVIDIA Call",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "NVIDIA Call": {
+      "main": [
+        [
+          {
+            "node": "Audit NVIDIA",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Audit NVIDIA": {
+      "main": [
+        [
+          {
+            "node": "NVIDIA Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "NVIDIA Success?": {
+      "main": [
+        [
+          {
+            "node": "Compile NVIDIA",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ],
+      "main2": [
+        [
+          {
+            "node": "Deterministic Fallback",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Compile Local": {
+      "main": [
+        [
+          {
+            "node": "Build Ops Alert",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Compile NVIDIA": {
+      "main": [
+        [
+          {
+            "node": "Build Ops Alert",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Deterministic Fallback": {
+      "main": [
+        [
+          {
+            "node": "Build Ops Alert",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Ops Alert": {
+      "main": [
+        [
+          {
+            "node": "Notify Ops?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Notify Ops?": {
+      "main": [
+        [
+          {
+            "node": "Send Ops Slack",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ],
+      "main2": [
+        []
+      ]
+    },
+    "Send Ops Slack": {
+      "main": [
+        []
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "meta": null,
+  "versionId": "6c2e3f9b-0cdc-4ede-9cac-61b1f4ac76f4"
+}

--- a/ops/n8n/workflows/site-sentinel.json
+++ b/ops/n8n/workflows/site-sentinel.json
@@ -1,0 +1,385 @@
+{
+  "id": "8f365fc2-50b3-4503-b6de-0ef6bc4177f5",
+  "name": "Site Sentinel",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "a9c315c8-249c-4af8-9c94-744740249ddb",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -880,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "triggerSource",
+              "value": "manual"
+            },
+            {
+              "name": "triggerLabel",
+              "value": "Manual run"
+            }
+          ]
+        },
+        "options": {
+          "keepOnlySet": false
+        }
+      },
+      "id": "905d3fef-f631-4e46-b11d-b0c9505b8393",
+      "name": "Label Manual Run",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [
+        -660,
+        -120
+      ]
+    },
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "minutes",
+              "minutesInterval": 5
+            }
+          ]
+        }
+      },
+      "id": "3dcc9982-31ef-4471-8f4b-35c74fdc7377",
+      "name": "Schedule Trigger",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        -880,
+        120
+      ]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "triggerSource",
+              "value": "scheduled"
+            },
+            {
+              "name": "triggerLabel",
+              "value": "Scheduled run"
+            }
+          ]
+        },
+        "options": {
+          "keepOnlySet": false
+        }
+      },
+      "id": "feae2f54-f132-4e9d-a6d6-af7cd988c3ff",
+      "name": "Label Scheduled Run",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 2,
+      "position": [
+        -660,
+        120
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "passThrough",
+        "mergeBy": "allEntries"
+      },
+      "id": "83db8ba8-0d36-486c-a1d0-7c3149e65dd0",
+      "name": "Merge Sources",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 1,
+      "position": [
+        -520,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const sourceItem = $input.first()?.json ?? {};\nconst triggerSource = sourceItem.triggerSource ?? 'manual';\nconst triggerLabel = sourceItem.triggerLabel ?? 'Manual run';\nreturn [\n  { json: { name: 'homepage', url: 'https://gimenez.dev/', expectJsonStatus: false, triggerSource, triggerLabel } },\n  { json: { name: 'health_api', url: 'https://gimenez.dev/api/health', expectJsonStatus: true, triggerSource, triggerLabel } },\n  { json: { name: 'war_room', url: 'https://gimenez.dev/war-room', expectJsonStatus: false, triggerSource, triggerLabel } },\n  { json: { name: 'war_room_data', url: 'https://gimenez.dev/api/war-room/data', expectJsonStatus: false, triggerSource, triggerLabel } }\n];"
+      },
+      "id": "e12372c3-cbcc-4524-a959-5369fa92d77f",
+      "name": "Build Targets",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -300,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $json.url }}",
+        "authentication": "none",
+        "options": {
+          "redirect": {
+            "redirect": {
+              "followRedirects": true,
+              "maxRedirects": 5
+            }
+          },
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true,
+              "responseFormat": "text",
+              "outputPropertyName": "body"
+            }
+          },
+          "timeout": 8000
+        }
+      },
+      "id": "a1f86a4f-883f-4f86-8d4f-792886ff5601",
+      "name": "Probe Targets",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        -100,
+        0
+      ],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const checkedAt = new Date().toISOString();\nconst workflowStaticData = $getWorkflowStaticData('global');\nconst inputs = $input.all();\nconst triggerSource = inputs[0]?.json?.triggerSource ?? 'scheduled';\nconst triggerLabel = inputs[0]?.json?.triggerLabel ?? (triggerSource === 'manual' ? 'Manual run' : 'Scheduled run');\nconst targets = [\n  { name: 'homepage', url: 'https://gimenez.dev/', expectJsonStatus: false },\n  { name: 'health_api', url: 'https://gimenez.dev/api/health', expectJsonStatus: true },\n  { name: 'war_room', url: 'https://gimenez.dev/war-room', expectJsonStatus: false },\n  { name: 'war_room_data', url: 'https://gimenez.dev/api/war-room/data', expectJsonStatus: false }\n];\n\nconst results = inputs.map((item) => {\n  const targetIndex = item.pairedItem?.item ?? 0;\n  const target = targets[targetIndex] || targets[0];\n  const bodyText = String(item.json.body || '');\n  let appStatus = null;\n\n  if (target.expectJsonStatus) {\n    try {\n      const parsed = JSON.parse(bodyText);\n      appStatus = parsed.status ?? null;\n    } catch (error) {\n      appStatus = bodyText ? 'invalid-json' : null;\n    }\n  }\n\n  const healthy = !item.json.error\n    && Number(item.json.statusCode || 0) >= 200\n    && Number(item.json.statusCode || 0) < 400\n    && (!target.expectJsonStatus || appStatus === 'healthy');\n\n  return {\n    name: target.name,\n    url: target.url,\n    healthy,\n    statusCode: item.json.statusCode ?? null,\n    statusMessage: item.json.statusMessage ?? null,\n    appStatus,\n    error: item.json.error ?? null,\n    bodyPreview: bodyText.slice(0, 160)\n  };\n});\n\nconst failures = results.filter((result) => !result.healthy);\nconst previousFailures = Number(workflowStaticData.consecutiveFailures || 0);\nconst consecutiveFailures = failures.length > 0 ? previousFailures + 1 : 0;\nconst shouldEscalate = failures.length > 0 && consecutiveFailures >= 2;\n\nworkflowStaticData.lastCheckedAt = checkedAt;\nworkflowStaticData.lastSummary = failures.length > 0 ? failures.map((failure) => failure.name).join(', ') : 'healthy';\nworkflowStaticData.consecutiveFailures = consecutiveFailures;\nworkflowStaticData.lastStatus = failures.length > 0 ? 'degraded' : 'healthy';\n\nreturn [\n  {\n    json: {\n      workflow: 'site-sentinel',\n      checkedAt,\n      triggerSource,\n      triggerLabel,\n      status: failures.length > 0 ? (shouldEscalate ? 'incident' : 'degraded') : 'healthy',\n      shouldEscalate,\n      consecutiveFailures,\n      summary: failures.length > 0\n        ? `${failures.length} failing checks: ${failures.map((failure) => failure.name).join(', ')}`\n        : 'all checks healthy',\n      results\n    }\n  }\n];"
+      },
+      "id": "75d7b7aa-cf60-44f1-a132-0f969c7621bc",
+      "name": "Evaluate Results",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        80,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const payload = $input.first().json;\nconst drillMode = $env.CONTROL_PLANE_DRILL === '1';\nconst shouldNotify = drillMode || payload.triggerSource === 'manual' || payload.status !== 'healthy';\nconst failingChecks = (payload.results || []).filter((result) => !result.healthy).map((result) => result.name);\nconst icon = payload.status === 'healthy'\n  ? ':white_check_mark:'\n  : payload.status === 'degraded'\n    ? ':warning:'\n    : ':rotating_light:';\nconst lines = [\n  `${icon} *Site Sentinel* ${String(payload.status || 'unknown').toUpperCase()}`,\n  `Run: ${payload.triggerLabel || payload.triggerSource || 'manual'}`,\n  `Checked: ${payload.checkedAt}`,\n  `Summary: ${payload.summary}`\n];\nif (drillMode) {\n  lines.push('Mode: control-plane drill');\n}\nif (failingChecks.length > 0) {\n  lines.push(`Failing checks: ${failingChecks.join(', ')}`);\n}\nreturn [\n  {\n    json: {\n      ...payload,\n      slackNotification: {\n        skip: !shouldNotify,\n        channel: 'C0ALX8C12TG',\n        text: lines.join('\\n')\n      }\n    }\n  }\n];"
+      },
+      "id": "8f129a4e-dcf2-45e6-b3ef-9f63c354dd8b",
+      "name": "Build Ops Alert",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        300,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "boolean": [
+            {
+              "value1": "={{ $json.slackNotification.skip !== true }}",
+              "value2": true
+            }
+          ]
+        }
+      },
+      "id": "0f4a67d4-3f38-42b0-8446-060af6c00ba8",
+      "name": "Notify Ops?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 1,
+      "position": [
+        520,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://slack.com/api/chat.postMessage",
+        "authentication": "none",
+        "sendHeaders": true,
+        "specifyHeaders": "json",
+        "jsonHeaders": "={{ JSON.stringify({ Authorization: 'Bearer ' + $env.SLACK_BOT_TOKEN, 'Content-Type': 'application/json; charset=utf-8' }) }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ channel: $json.slackNotification.channel, text: $json.slackNotification.text }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true,
+              "responseFormat": "json"
+            }
+          },
+          "timeout": 8000
+        }
+      },
+      "id": "96c6b8f8-0c2d-4c9f-b5ae-7c2c7c96fb08",
+      "name": "Send Ops Slack",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.4,
+      "position": [
+        760,
+        -120
+      ],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const payload = $input.first().json;\n\nif (!payload.shouldEscalate) {\n  return [{ json: payload }];\n}\n\nthrow new Error(JSON.stringify({\n  workflow: payload.workflow,\n  checkedAt: payload.checkedAt,\n  consecutiveFailures: payload.consecutiveFailures,\n  summary: payload.summary,\n  failingChecks: payload.results.filter((result) => !result.healthy)\n}));"
+      },
+      "id": "9702983f-f0c8-4646-a87c-7369cf5eb7ef",
+      "name": "Escalate Incident",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        980,
+        0
+      ]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Label Manual Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Schedule Trigger": {
+      "main": [
+        [
+          {
+            "node": "Label Scheduled Run",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Label Manual Run": {
+      "main": [
+        [
+          {
+            "node": "Merge Sources",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Label Scheduled Run": {
+      "main": [
+        [
+          {
+            "node": "Merge Sources",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge Sources": {
+      "main": [
+        [
+          {
+            "node": "Build Targets",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Targets": {
+      "main": [
+        [
+          {
+            "node": "Probe Targets",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Probe Targets": {
+      "main": [
+        [
+          {
+            "node": "Evaluate Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Evaluate Results": {
+      "main": [
+        [
+          {
+            "node": "Build Ops Alert",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Ops Alert": {
+      "main": [
+        [
+          {
+            "node": "Notify Ops?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Notify Ops?": {
+      "main": [
+        [
+          {
+            "node": "Send Ops Slack",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ],
+      "main2": [
+        [
+          {
+            "node": "Escalate Incident",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Ops Slack": {
+      "main": [
+        [
+          {
+            "node": "Escalate Incident",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "meta": null,
+  "versionId": "e9e8e898-3de8-4d2c-bd18-4286eac27afa"
+}

--- a/src/lib/docs-config.ts
+++ b/src/lib/docs-config.ts
@@ -12,6 +12,7 @@ export interface DocEntry {
 export const docsNav: DocEntry[] = [
   { slug: "setup", file: "SETUP.md", title: "Setup" },
   { slug: "deploy", file: "DEPLOY-CLOUDRUN.md", title: "Deployment (Cloud Run)" },
+  { slug: "n8n-control-plane", file: "N8N-CONTROL-PLANE.md", title: "Edge Control Plane (n8n)" },
   { slug: "gcp-observability", file: "GCP-OBSERVABILITY-MAP.md", title: "GCP Observability (Console & Mobile)" },
   { slug: "traffic-cost", file: "TRAFFIC-AND-COST.md", title: "Traffic & Cost" },
   { slug: "ci-tests", file: "CI-AND-TESTS.md", title: "CI & Tests" },


### PR DESCRIPTION
## Summary
- add the edge control plane design doc and docs nav entry
- version the first n8n workflow set for site health, DNS/SSL, deploys, cost governance, and inference routing
- document the current Pi runtime constraints and drill mode so the portfolio story stays honest

## Verification
- npm run lint
- npm run test
- npm run build
- npm run test:e2e
- terraform init -input=false
- terraform validate
- jq empty ops/n8n/workflows/*.json