### PR TITLE
chore: Vercel primary deploy + docs (GCP preserved)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,7 @@ CHAT_DAILY_BUDGET=900
 # =============================================================================
 # BUILD CONFIG
 # =============================================================================
+# Production (Vercel): set NEXT_PUBLIC_SITE_URL in the Vercel project to your custom domain (e.g. https://gimenez.dev).
 NEXT_PUBLIC_SITE_URL=https://gimenez.dev
 
 # =============================================================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # CI: lint, build, unit tests, e2e (Cypress), Terraform validate.
-# Required to pass before merging to main. Cloud Run deploy is unchanged (Cloud Build on push to main).
+# Required to pass before merging to main. Production is Vercel on push to main; Cloud Build/terraform remain optional for GCP rollback.
 
 name: CI
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,27 +8,36 @@
 
 ### Overview
 
-This is a **Next.js 16 portfolio site** (`gimenez.dev`) with an AI chat feature and live War Room observability dashboard. Single Next.js process deployed on **GCP Cloud Run**. Default production mode keeps a **Global External Application Load Balancer** with Cloud CDN and Cloud Armor in front of the custom domain. Low-cost mode is optional and uses the direct Cloud Run URL instead.
+This is a **Next.js 16 portfolio site** (`gimenez.dev`) with an AI chat feature and live War Room observability dashboard.
 
-### Deployment (auto-deploy on)
+**Primary production hosting:** **Vercel** (GitHub integration; push to `main` deploys). See **`docs/VERCEL-DEPLOY.md`** for env vars and Namecheap DNS.
 
-**Push to `main` = deploy.** Cloud Build is connected to the repo; each push to `main` triggers a build that:
+**GCP path (preserved, optional rollback):** `terraform/`, `cloudbuild.yaml`, and `Dockerfile` are kept. You can still deploy to **Cloud Run** behind a Global External ALB with Cloud CDN and Cloud Armor, or use low-cost direct Cloud Run ingress. Nothing in this migration deletes that stack.
 
-1. Builds the Docker image (Dockerfile uses `--platform=linux/amd64` for Cloud Run).
-2. Pushes to Artifact Registry (`portfolio/app`).
-3. Deploys to Cloud Run with `--set-secrets` for `INFERENCIA_API_KEY` and `INFERENCIA_BASE_URL` from Secret Manager.
+### Deployment
 
-**Trigger hygiene:** The GitHub trigger should use **`cloudbuild.yaml`** and push to the managed Artifact Registry repo **`portfolio`**. Avoid leaving a Cloud Run UI "source deploy" trigger active long-term; it creates a second repo (`cloud-run-source-deploy`) that can accumulate stale images and cost drift.
+**Vercel (default)**
 
-So: **code, docs, and build fixes → commit and push to main**; the next build will deploy. **You do not need to run `docker build` / `docker push` / `gcloud run services update` manually** when auto-deploy is on. Use that manual flow only if the Cloud Build trigger isn't connected or you need a one-off deploy without pushing. No need to run Terraform for app-only changes. Use Terraform only when changing infrastructure (LB, WAF, DNS, monitoring). Analytics: **Google Analytics 4 only** (optional `NEXT_PUBLIC_GA_MEASUREMENT_ID`).
+1. Import the GitHub repo in Vercel; set Production branch to `main`.
+2. Configure environment variables (Inferencia, admin, optional Firebase, etc.) — see **`docs/VERCEL-DEPLOY.md`**.
+3. Add `gimenez.dev` / `www` under **Domains** and apply the DNS records Vercel shows (Namecheap: usually **A `@` → `76.76.21.21`**, **CNAME `www` → `cname.vercel-dns.com`**).
+4. After traffic is on Vercel, **disable the Cloud Build trigger** in GCP (optional but recommended) so pushes to `main` do not keep building container images you are not serving.
 
-**Preventing "old version" after Terraform apply:** Terraform has `lifecycle { ignore_changes = [template[0].containers[0].image] }` on the Cloud Run service so **the container image is only updated by Cloud Build**. A plain `terraform apply` will not overwrite the live image with an older `portfolio/app:latest`; it only updates env, secrets, and scaling. Deploy app changes by pushing to `main` (Cloud Build) or running `gcloud builds submit --config=cloudbuild.yaml .`.
+**GCP / Cloud Run (optional rollback)**
+
+When you want the old path again: re-enable Cloud Build, point DNS back at the load balancer IP (or Run URL in low-cost mode), and follow **`docs/DEPLOY-CLOUDRUN.md`**. Push to `main` with the trigger on builds the Docker image (`--platform=linux/amd64`), pushes to Artifact Registry, and deploys to Cloud Run with `--set-secrets` for Inferencia.
+
+**Trigger hygiene (GCP):** The GitHub trigger should use **`cloudbuild.yaml`** and push to the managed Artifact Registry repo **`portfolio`**.
+
+**Preventing "old version" after Terraform apply:** Terraform has `lifecycle { ignore_changes = [template[0].containers[0].image] }` on the Cloud Run service so **the container image is only updated by Cloud Build**. A plain `terraform apply` will not overwrite the live image with an older `portfolio/app:latest`; it only updates env, secrets, and scaling.
+
+Analytics: **Google Analytics 4 only** (optional `NEXT_PUBLIC_GA_MEASUREMENT_ID`).
 
 ### Running the app
 
 - **Node:** 20.9+ required (see `engines` in `package.json`).
 - `npm run dev` — starts dev server on port 3000
-- `npm run build` — production build (standalone output for Cloud Run)
+- `npm run build` — production build (**Vercel:** default Next output; **Docker/Cloud Run:** `standalone` when `VERCEL` is unset — see `next.config.ts`)
 - `npm run lint` — ESLint (currently 0 errors, 0 warnings)
 
 **Verify before commit / after changes:** Run `npm run build`, `npm run lint`, and `cd terraform && terraform init -input=false && terraform validate`. All must pass.
@@ -65,7 +74,7 @@ So: **code, docs, and build fixes → commit and push to main**; the next build 
 - Copy `.env.example` to `.env.local`. All portfolio pages work without API keys.
 - `INFERENCIA_API_KEY` + `INFERENCIA_BASE_URL` are needed for the AI chat. Without them, chat returns 503 but all pages work.
 - **RAG:** By default the chat uses the file-based knowledge base. For vector search, use GCP Cloud SQL (PostgreSQL + pgvector): set `enable_rag_cloud_sql = true` in Terraform; apply schema (`scripts/init-rag-db.sql`) and seed (`npx tsx scripts/seed-rag-db.ts`). Cloud Run gets `CLOUD_SQL_CONNECTION_NAME`, `RAG_DB_*` from Terraform when enabled.
-- In production on Cloud Run, these are set via **GCP Secret Manager** (never in env vars directly); `cloudbuild.yaml` passes them with `--set-secrets`.
+- In production on **Vercel**, set secrets in the Vercel project (or use `vercel env`). On **GCP Cloud Run**, Inferencia values come from **Secret Manager** via `cloudbuild.yaml` `--set-secrets`.
 - Optional: `NEXT_PUBLIC_GA_MEASUREMENT_ID` for Google Analytics 4.
 - **`GOOGLE_CLOUD_PROJECT`** — Set in Terraform for Cloud Run so logs include `logging.googleapis.com/trace` and appear in **Trace** and Logs Explorer. Required for Observability → Trace to show requests.
 

--- a/README.md
+++ b/README.md
@@ -2,18 +2,17 @@
 
 **Live site:** [gimenez.dev](https://gimenez.dev) · **War Room:** [gimenez.dev/war-room](https://gimenez.dev/war-room)
 
-A **production Next.js portfolio** on GCP Cloud Run with an AI-powered recruiter chat, live observability (War Room), session analytics, and infra-as-code. Built to demonstrate the same engineering practices used in high-availability systems: observability, security, rate limiting, and cost control.
+A **production Next.js portfolio** deployed primarily on **Vercel** (`gimenez.dev`), with an AI-powered recruiter chat, live observability (War Room), session analytics, and optional **GCP** infra preserved in-repo for rollback (Cloud Run, ALB, Terraform, Cloud Build — not removed).
+
 
 ---
 
 ## What this repo is
 
 - **Portfolio** — Professional site (about, work, architecture case study, contact). Responsive, dark theme.
-- **AI chat** — RAG-backed assistant for recruiters; answers from a structured knowledge base. Rate-limited, prompt-injection hardened, with optional conversation memory and session analytics (Firestore).
-- **War Room** — Real-time dashboard: health tiles, latency charts, error feed, “Explain with AI” for errors. Same mindset as production NOC dashboards.
-- **Infrastructure** — Single Next.js app on Cloud Run behind a Global External ALB, Cloud CDN, and Cloud Armor (WAF). Terraform for all GCP resources. Push to `main` → Cloud Build → deploy. Optional **$20 budget kill switch**: when the threshold is exceeded, a Cloud Function scales Cloud Run to zero so cost stops even if you’re not online. Free tier used wherever possible (scale-to-zero, file-based RAG by default, CDN caching).
-
-No placeholder content. The site is live; the chat, health checks, and War Room are wired to real endpoints and (in prod) to GCP.
+- **AI chat** — RAG-backed assistant for recruiters; rate-limited and prompt-injection hardened; optional Firestore memory.
+- **War Room** — Health tiles, latency charts, error feed, “Explain with AI”.
+- **Hosting** — **Vercel** by default; full **GCP** stack (Cloud Run + ALB + Terraform + Cloud Build) remains in-repo if you switch back.
 
 ---
 
@@ -21,11 +20,11 @@ No placeholder content. The site is live; the chat, health checks, and War Room 
 
 | Area | What’s in this repo |
 |------|----------------------|
-| **Cloud & IaC** | GCP Cloud Run, ALB, CDN, Armor, Secret Manager, Terraform (services, LB, WAF, monitoring, budget + Pub/Sub → function). |
+| **Cloud & IaC** | **Vercel** production path; optional **GCP** Cloud Run, ALB, CDN, Armor, Secret Manager, Terraform (services, LB, WAF, monitoring, budget + Pub/Sub → function). |
 | **Observability** | In-app War Room (metrics, errors, events), structured JSON logs, trace IDs, uptime checks, alert policy. |
-| **Security** | CSP/HSTS/X-Frame-Options, rate limiting (app + Cloud Armor), prompt-injection defense (OWASP LLM01/07), secrets in Secret Manager, ingress only from ALB. |
+| **Security** | CSP/HSTS/X-Frame-Options, rate limiting in the app, prompt-injection defense (OWASP LLM01/07), optional Cloud Armor on the GCP path. |
 | **AI / LLM** | RAG over a local knowledge base, streaming chat (OpenAI-compatible API), response caching, token/message limits. |
-| **Reliability & cost** | Health checks, scale-to-zero, optional **$20 budget kill switch** (Pub/Sub → function sets Cloud Run max-instances=0). Free tier first; CDN caching. |
+| **Reliability & cost** | Health checks; optional **$20 budget kill switch** on GCP (Pub/Sub → function sets Cloud Run max-instances=0). |
 
 **Target roles:** Senior / Staff / SRE / Cloud Architect — backend, distributed systems, observability, GCP. Open to remote and select markets.
 
@@ -45,12 +44,12 @@ No placeholder content. The site is live; the chat, health checks, and War Room 
 
 ## Features
 
-- **Next.js 16** — App Router, React 19, TypeScript, Tailwind. Standalone output for Cloud Run.
+- **Next.js 16** — App Router, React 19, TypeScript, Tailwind. `standalone` output for Docker/Cloud Run only; Vercel uses the default serverless build.
 - **AI chat** — Inferencia (OpenAI-compatible). RAG from a file-based knowledge base or **GCP Cloud SQL (PostgreSQL + pgvector)** for vector search. Per-IP and session rate limits, daily budget, response cache. Prompt-injection checks; conversation memory and session analytics in Firestore when configured.
 - **War Room** — Status tiles (inference, RAG, rate limiter, logging, trace), P50/P95 latency, request/error volume, recent events (errors, cold starts, rate limits). “Explain with AI” sends error context to the same LLM for plain-language explanation.
 - **Admin** — **Administration Board** at `/admin` or `/admin/board`: single pane with System (War Room), Recruiters (sessions + emails + conversation drill-down), Logs (Cloud Run logs with trace links), and Metrics (Prometheus exposition). Also `/admin/conversations` and `/admin/logs` as deep links. Protected by admin secret; same secret for UI and API.
-- **Infrastructure** — Terraform: Cloud Run, Artifact Registry, Secret Manager, global static IP, serverless NEG, backend + CDN, Cloud Armor (rate limits, scanner block, path traversal, adaptive DDoS), URL map, HTTPS redirect, managed SSL, uptime checks, alert policy. Optional: **$20** billing budget with email + Pub/Sub; Cloud Function subscribes and sets Cloud Run `max-instances=0` when threshold is exceeded.
-- **CI/CD** — Cloud Build on push to `main`: build image (linux/amd64), push to Artifact Registry, deploy to Cloud Run with secrets.
+- **Infrastructure (optional GCP)** — Terraform: Cloud Run, Artifact Registry, Secret Manager, global static IP, serverless NEG, backend + CDN, Cloud Armor, URL map, managed SSL, uptime checks, budget + Pub/Sub → function. **Primary production:** Vercel — see [docs/VERCEL-DEPLOY.md](./docs/VERCEL-DEPLOY.md).
+- **CI/CD** — GitHub Actions on every PR/push to `main`. **Production deploy:** Vercel on push to `main` when the GitHub integration is enabled. `cloudbuild.yaml` remains for optional GCP image builds.
 
 ---
 
@@ -61,10 +60,10 @@ No placeholder content. The site is live; the chat, health checks, and War Room 
 | App | Next.js 16, React 19, TypeScript, Tailwind |
 | AI | Vercel AI SDK, Inferencia (OpenAI-compatible), local RAG; optional **Cloud SQL + pgvector** + Gemini embeddings |
 | Data | Firestore (chat sessions, memory, analytics when configured) |
-| Hosting | GCP Cloud Run (scale-to-zero, 1 max instance) |
-| Edge | Global External ALB, Cloud CDN, Cloud Armor |
+| Hosting | **Vercel** (primary) · optional GCP Cloud Run (rollback in `terraform/`) |
+| Edge | Vercel Edge Network · optional GCP ALB + Cloud CDN + Cloud Armor |
 | IaC | Terraform (Run, LB, WAF, Pub/Sub, Cloud Function for budget kill) |
-| CI/CD | Cloud Build; secrets from Secret Manager |
+| CI/CD | GitHub Actions + **Vercel** Git integration; optional Cloud Build + Secret Manager |
 | Observability | In-memory telemetry → War Room; **Prometheus** `/api/metrics` (text format, admin-only); stdout JSON → Cloud Logging; trace IDs → Cloud Trace; uptime checks + alert |
 
 ---
@@ -120,16 +119,16 @@ Open [http://localhost:3000](http://localhost:3000). Chat: [http://localhost:300
 | `NEXT_PUBLIC_GA_MEASUREMENT_ID` | No | Google Analytics 4 |
 | Optional RAG | `GOOGLE_API_KEY`; on GCP, Terraform sets Cloud SQL (pgvector) env; locally use Cloud SQL Proxy + `RAG_DB_*` | File-based RAG by default; vector RAG when Cloud SQL is configured |
 
-See `.env.example` for the full list. **Do not commit secrets.** Production uses GCP Secret Manager (see [AGENTS.md](./AGENTS.md) and [docs/DEPLOY-CLOUDRUN.md](./docs/DEPLOY-CLOUDRUN.md)).
+See `.env.example` for the full list. **Do not commit secrets.** On Vercel, set secrets in the project dashboard (or `vercel env`). On GCP, Secret Manager + Cloud Build still apply if you use that path — see [docs/DEPLOY-CLOUDRUN.md](./docs/DEPLOY-CLOUDRUN.md) and [docs/VERCEL-DEPLOY.md](./docs/VERCEL-DEPLOY.md).
 
 ---
 
 ## Deployment
 
-- **App:** Push to `main` → Cloud Build builds the image, pushes to Artifact Registry, deploys to Cloud Run with secrets. No manual deploy needed when the trigger is connected.
-- **Infrastructure:** `cd terraform && terraform init && terraform plan && terraform apply`. Use `terraform.tfvars` for `project_id`, `region`, optional `billing_account_id` / `budget_alert_email` for budget and automatic kill switch.
+- **Primary (Vercel):** Import the GitHub repo, configure env vars, add `gimenez.dev` in Vercel Domains, then point Namecheap DNS as shown in [docs/VERCEL-DEPLOY.md](./docs/VERCEL-DEPLOY.md). Push to `main` deploys production.
+- **Optional GCP rollback:** `terraform/`, `cloudbuild.yaml`, and `Dockerfile` are unchanged. To redeploy on Cloud Run, re-enable your Cloud Build trigger and follow [docs/DEPLOY-CLOUDRUN.md](./docs/DEPLOY-CLOUDRUN.md).
 
-Details: [docs/DEPLOY-CLOUDRUN.md](./docs/DEPLOY-CLOUDRUN.md), [AGENTS.md](./AGENTS.md).
+Details: [docs/VERCEL-DEPLOY.md](./docs/VERCEL-DEPLOY.md), [docs/DEPLOY-CLOUDRUN.md](./docs/DEPLOY-CLOUDRUN.md), [AGENTS.md](./AGENTS.md).
 
 **Scripts:** `npm run dev` · `npm run build` · `npm run start` · `npm run lint`  
 **Docker:** `docker build -t lgportfolio .` then run with `-e INFERENCIA_API_KEY` and `-e INFERENCIA_BASE_URL`; see `Dockerfile` for platform (linux/amd64).
@@ -139,7 +138,7 @@ Details: [docs/DEPLOY-CLOUDRUN.md](./docs/DEPLOY-CLOUDRUN.md), [AGENTS.md](./AGE
 Run these before pushing or to confirm the repo is healthy:
 
 ```bash
-npm run build          # Production build (must succeed for Cloud Run)
+npm run build          # Production build (must succeed on Vercel and locally)
 npm run lint           # ESLint (0 errors, 0 warnings)
 npm run test           # Vitest unit tests (security, rate-limit, version)
 npm run test:e2e       # Cypress smoke tests (requires app running on :3000)
@@ -150,14 +149,14 @@ cd terraform && terraform init -input=false && terraform validate   # IaC valid
 
 ## Production readiness
 
-- **Build** — `output: "standalone"`; `npm run build` and `npm run lint` (0 errors).
+- **Build** — `standalone` output only for Docker/Cloud Run; Vercel uses the default Next.js build. `npm run build` and `npm run lint` (0 errors).
 - **Tests** — Vitest unit tests (security, rate-limit, version); Cypress e2e smoke tests; CI via GitHub Actions.
 - **Version** — Single source of truth in `package.json`, read via `src/lib/version.ts`. Health API, War Room, and UI all read from this one place.
-- **Security** — CSP, HSTS, X-Frame-Options; rate limiting (app + Cloud Armor); prompt-injection defense; secrets in Secret Manager; Cloud Run ingress only from ALB. No secrets in client responses or logs.
+- **Security** — CSP, HSTS, X-Frame-Options; rate limiting in the app; prompt-injection defense; no secrets in client responses or logs. (Optional GCP Cloud Armor when using the ALB path.)
 - **SLOs** — Tracked in War Room: availability (99.5%), P95 latency (<500ms), error rate (<5%), budget headroom (>10%). See [ADRs](./docs/adr/).
 - **Health** — `/api/health` for uptime checks; 503 when degraded.
 - **Telemetry** — Structured JSON logs, trace IDs, in-memory metrics for the War Room; metrics reset on cold start (documented).
-- **Cost control** — Optional **$20** budget kill switch; when configured in Terraform (`billing_account_id`, `budget_alert_email`), a Cloud Function automatically scales Cloud Run to 0 on threshold breach. Manual fallback: `./scripts/disable-project-spend.sh`. See [docs/CHECKLIST-FINAL-SWEEP.md](./docs/CHECKLIST-FINAL-SWEEP.md) for a full sweep checklist.
+- **Cost control** — Vercel billing + optional GCP **$20** budget kill switch when that stack is active; see [docs/CHECKLIST-FINAL-SWEEP.md](./docs/CHECKLIST-FINAL-SWEEP.md) for a full sweep checklist.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ This folder is the single source of truth for that content. The sidebar and inde
 
 ## Contents
 
-- **Deployment & setup:** `SETUP.md`, `DEPLOY-CLOUDRUN.md`, `CHAT-SECRETS.md`
+- **Deployment & setup:** `SETUP.md`, `VERCEL-DEPLOY.md`, `DEPLOY-CLOUDRUN.md`, `CHAT-SECRETS.md`
 - **Operations:** `TRAFFIC-AND-COST.md`, `CI-AND-TESTS.md`, `DEBUGGING-CHAT.md`, `GCP-OBSERVABILITY-MAP.md`
 - **Decisions:** `DECISIONS.md`, `ADMIN-BOARD.md`
 - **Architecture decision records:** `adr/001-*.md`, `adr/002-*.md`, `adr/003-*.md`

--- a/docs/VERCEL-DEPLOY.md
+++ b/docs/VERCEL-DEPLOY.md
@@ -1,0 +1,63 @@
+# Deploy on Vercel (primary)
+
+GCP assets (`terraform/`, `cloudbuild.yaml`, `Dockerfile`) stay in the repo for rollback; production traffic is intended to run on **Vercel** after you point DNS here.
+
+## 1. Create the project
+
+1. [Vercel Dashboard](https://vercel.com/dashboard) → **Add New…** → **Project** → import `menezmethod/lgportfolio`.
+2. **Framework Preset:** Next.js (auto-detected). **Node:** 20.x (matches `package.json` engines).
+3. **Root directory:** `.` (default).
+4. Deploy once on the default `*.vercel.app` URL and confirm pages load.
+
+## 2. Environment variables
+
+In **Project → Settings → Environment Variables**, set at least:
+
+| Variable | Notes |
+|----------|--------|
+| `INFERENCIA_API_KEY` | Required for `/api/chat` and War Room “explain error”. |
+| `INFERENCIA_BASE_URL` | OpenAI-compatible base URL (e.g. `https://llm.menezmethod.com/v1`). |
+| `INFERENCIA_CHAT_MODEL` | Optional; app has a default if unset. |
+| `ADMIN_SECRET` | Required for `/admin/*` and admin APIs. |
+| `NEXT_PUBLIC_SITE_URL` | `https://gimenez.dev` (canonical URL / metadata). |
+
+Optional (same behavior as on Cloud Run):
+
+- `FIREBASE_SERVICE_ACCOUNT_JSON` — Firestore session memory / analytics.
+- `GOOGLE_CLOUD_PROJECT` — only if you still want **Admin → Logs** to read Cloud Logging from GCP.
+- `NEXT_PUBLIC_GA_MEASUREMENT_ID` — Google Analytics 4.
+- RAG Cloud SQL vars — only if you use Postgres/pgvector (see `SETUP.md`).
+
+Redeploy after changing env vars (**Deployments → … → Redeploy** or push to `main`).
+
+## 3. Custom domain + Namecheap DNS
+
+In Vercel: **Project → Settings → Domains** → add `gimenez.dev` and `www.gimenez.dev`. Vercel shows the exact records to use; prefer those over anything generic.
+
+**Typical setup when DNS stays at Namecheap** (Advanced DNS):
+
+| Type | Host | Value |
+|------|------|--------|
+| **A** | `@` | `76.76.21.21` |
+| **CNAME** | `www` | `cname.vercel-dns.com.` |
+
+TTL: Automatic or 1 min is fine. Remove old records that pointed the apex/`www` at the GCP load balancer IP so only Vercel remains.
+
+Propagation is usually minutes; SSL is issued by Vercel after DNS verifies.
+
+## 4. CLI (optional)
+
+```bash
+npm i -g vercel   # if needed
+vercel link       # in repo root; links to the Vercel project
+vercel env pull   # optional: download envs to .env.local for local dev
+```
+
+## 5. Stop paying for the old GCP app path (manual)
+
+After `gimenez.dev` serves Vercel and looks correct:
+
+1. In **Google Cloud Console → Cloud Build → Triggers**: disable the deploy trigger for this repo (stops image churn on every push).
+2. Optionally scale **Cloud Run** `lgportfolio` **max instances** to `0` or delete the trigger only—Terraform and `cloudbuild.yaml` remain for a future return to GCP.
+
+You do **not** need to delete `terraform/` or remove docs; this repo stays dual-capable.

--- a/next.config.ts
+++ b/next.config.ts
@@ -26,8 +26,11 @@ const securityHeaders = [
   },
 ];
 
+/** Vercel sets `VERCEL=1` at build time; Docker/Cloud Run builds omit it and use standalone output. */
+const isVercel = Boolean(process.env.VERCEL);
+
 const nextConfig: NextConfig = {
-  output: "standalone",
+  ...(!isVercel ? { output: "standalone" as const } : {}),
   images: {
     unoptimized: true,
   },

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -79,6 +79,41 @@ function normalizeAssistantContent(text: string): string {
   return out.trim();
 }
 
+function extractAssistantFromRawStream(raw: string): string {
+  if (!raw?.trim()) return '';
+  const parts: string[] = [];
+  const lines = raw.split('\n');
+
+  for (const line of lines) {
+    const idx = line.indexOf(':');
+    if (idx <= 0) continue;
+    const payload = line.slice(idx + 1).trim();
+    if (!payload) continue;
+
+    try {
+      const parsed = JSON.parse(payload) as
+        | string
+        | { text?: string; content?: string; reasoning?: string; delta?: { text?: string } };
+
+      if (typeof parsed === 'string') {
+        parts.push(parsed);
+        continue;
+      }
+
+      if (parsed.text) parts.push(parsed.text);
+      if (parsed.content) parts.push(parsed.content);
+      if (parsed.delta?.text) parts.push(parsed.delta.text);
+      if (parsed.reasoning && !parsed.text && !parsed.content && !parsed.delta?.text) {
+        parts.push(parsed.reasoning);
+      }
+    } catch {
+      // Non-JSON payload line; ignore protocol control chunks.
+    }
+  }
+
+  return parts.join('').trim();
+}
+
 /** Remove duplicated block if the model repeated the same content twice (e.g. full answer copy-pasted). */
 function dedupeRepeatedResponse(text: string): string {
   if (!text?.trim()) return text;
@@ -207,6 +242,7 @@ export default function Chat() {
 
         const decoder = new TextDecoder();
         let assistantContent = '';
+        let rawStream = '';
         let usedDataStream = false;
 
         while (true) {
@@ -214,6 +250,7 @@ export default function Chat() {
           if (done) break;
 
           const decoded = decoder.decode(value, { stream: true });
+          rawStream += decoded;
           const lines = decoded.split('\n');
           let hadDataStreamLine = false;
 
@@ -244,6 +281,28 @@ export default function Chat() {
               const last = next[next.length - 1];
               if (last?.role === 'assistant') last.content = assistantContent;
               else next.push({ id: Date.now().toString(), role: 'assistant', content: assistantContent });
+              return next;
+            });
+          }
+        }
+        if (!assistantContent.trim()) {
+          const extracted = extractAssistantFromRawStream(rawStream);
+          if (extracted) {
+            assistantContent = extracted;
+            setMessages((prev) => {
+              const next = [...prev];
+              const last = next[next.length - 1];
+              if (last?.role === 'assistant') last.content = assistantContent;
+              else next.push({ id: Date.now().toString(), role: 'assistant', content: assistantContent });
+              return next;
+            });
+          } else {
+            const fallback = 'The model returned an empty response. Please retry in a few seconds.';
+            setMessages((prev) => {
+              const next = [...prev];
+              const last = next[next.length - 1];
+              if (last?.role === 'assistant') last.content = fallback;
+              else next.push({ id: Date.now().toString(), role: 'assistant', content: fallback });
               return next;
             });
           }

--- a/src/lib/docs-config.ts
+++ b/src/lib/docs-config.ts
@@ -11,6 +11,7 @@ export interface DocEntry {
 
 export const docsNav: DocEntry[] = [
   { slug: "setup", file: "SETUP.md", title: "Setup" },
+  { slug: "vercel", file: "VERCEL-DEPLOY.md", title: "Deployment (Vercel)" },
   { slug: "deploy", file: "DEPLOY-CLOUDRUN.md", title: "Deployment (Cloud Run)" },
   { slug: "gcp-observability", file: "GCP-OBSERVABILITY-MAP.md", title: "GCP Observability (Console & Mobile)" },
   { slug: "traffic-cost", file: "TRAFFIC-AND-COST.md", title: "Traffic & Cost" },


### PR DESCRIPTION
## Summary
- Document **Vercel** as the primary production path (`docs/VERCEL-DEPLOY.md`: env vars + Namecheap DNS).
- Keep **GCP** assets untouched (`terraform/`, `cloudbuild.yaml`, `Dockerfile`) for optional rollback.
- `next.config.ts`: use **default** Next output on Vercel (`VERCEL=1`); keep **`standalone`** for Docker/Cloud Run builds.
- Refresh **README**, **AGENTS**, docs index, and CI header comment for dual hosting clarity.
- Includes the **chat empty-stream fallback** UX fix (already merged separately on main as #29 — kept here for a clean branch if needed; squash will dedupe).

## DNS (Namecheap — typical)
Follow **Vercel → Project → Settings → Domains** for exact values. Usually:
- `@` **A** → `76.76.21.21`
- `www` **CNAME** → `cname.vercel-dns.com`

## Post-merge (manual)
1. Import/link repo in Vercel + set env vars.
2. Add domain in Vercel, update Namecheap DNS, verify SSL.
3. Disable **Cloud Build** trigger in GCP to stop unused deploy spend.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test`
- [x] `terraform init -input=false -backend=false && terraform validate`

Made with [Cursor](https://cursor.com)