### PR TITLE
chore: weekly hireability audit auto-updates [2026-06-04]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,9 @@ GOOGLE_CLOUD_REGION=us-east4
 # ADMIN — Secret to view chat sessions at /admin/conversations
 # =============================================================================
 # ADMIN_SECRET=your-admin-secret-here
+# Production: EATUXW6+u1tJrwAg/Qiu2DJxrSruPeeipi2OM+AiB/M=
+# Set on Vercel as encrypted env var, used by /api/metrics and /admin/* routes.
+# Pass as header: X-Admin-Secret: <secret> or Authorization: Bearer <secret>
 
 # =============================================================================
 # CHAT UI CONFIGURATION (optional)

--- a/GOOGLE_ANALYTICS_SETUP.md
+++ b/GOOGLE_ANALYTICS_SETUP.md
@@ -1,0 +1,155 @@
+# Google Tag Manager Setup Guide
+
+This guide explains how to set up Google Tag Manager (GTM) for your React portfolio using best practices.
+
+## Prerequisites
+
+1. A Google Tag Manager account
+2. Your GTM Container ID (format: GTM-XXXXXXXX)
+
+## Setup Instructions
+
+### 1. Create Google Tag Manager Container
+
+1. Go to [Google Tag Manager](https://tagmanager.google.com/)
+2. Create a new GTM container for your portfolio
+3. Note your Container ID (starts with "GTM-")
+
+### 2. Environment Configuration
+
+1. Create a `.env` file in your project root:
+```bash
+REACT_APP_GA_MEASUREMENT_ID=GTM-TWTCVMJ
+```
+
+2. Replace `GTM-TWTCVMJ` with your actual Container ID if different
+
+### 3. Implementation Details
+
+The Google Tag Manager implementation includes:
+
+#### Core Features
+- **Automatic page view tracking** on app initialization
+- **Custom event tracking** for user interactions
+- **External link tracking** for social media clicks
+- **Contact form tracking** for email interactions
+- **GTM dataLayer integration** for flexible tracking
+
+#### Tracking Functions Available
+
+```javascript
+// Track page views
+trackPageView('/about');
+
+// Track custom events
+trackEvent('User Interaction', 'button_click', 'contact_button');
+
+// Track contact interactions
+trackContactInteraction('email_click');
+
+// Track external links
+trackExternalLink('https://github.com/user', 'GitHub');
+
+// Track section views
+trackSectionView('about');
+
+// Track downloads
+trackDownload('/resume.pdf', 'Resume Download');
+```
+
+#### GTM dataLayer Events
+All events are pushed to the GTM dataLayer for flexible configuration:
+- `page_view` - Page view events
+- `custom_event` - Custom user interactions
+- `contact_interaction` - Contact form events
+- `external_link` - Outbound link clicks
+
+### 4. Privacy and Compliance
+
+#### GDPR Compliance
+- Analytics only runs when a valid GTM Container ID is provided
+- No personal data is collected
+- Users can opt-out via browser settings
+
+#### Best Practices Implemented
+- Environment-based configuration
+- GTM script loading in HTML head
+- Error handling for missing GTM ID
+- Clean separation of concerns
+
+### 5. Testing
+
+#### Development Testing
+1. Open browser developer tools
+2. Check the Console tab for GTM debug messages
+3. Verify events are being pushed to dataLayer
+
+#### Production Verification
+1. Deploy your site
+2. Visit your Google Tag Manager dashboard
+3. Check Real-Time reports for incoming data
+
+### 6. Customization
+
+#### Adding More Tracking
+To add tracking to new components:
+
+```javascript
+import { trackEvent } from '../utils/analytics';
+
+// In your component
+<button onClick={() => trackEvent('Portfolio', 'project_view', 'project_name')}>
+  View Project
+</button>
+```
+
+#### Tracking Custom Dimensions
+For more advanced tracking, modify the analytics utility:
+
+```javascript
+// In src/utils/analytics.js
+export const trackCustomDimension = (dimension, value) => {
+  ReactGA.set({
+    [dimension]: value
+  });
+};
+```
+
+### 7. Troubleshooting
+
+#### Common Issues
+
+1. **No data appearing in GTM**
+   - Verify your Container ID is correct
+   - Check that the `.env` file is in the project root
+   - Ensure the environment variable starts with `REACT_APP_`
+
+2. **Events not tracking**
+   - Check browser console for errors
+   - Verify GTM is loaded properly
+   - Ensure tracking functions are called correctly
+
+3. **Development vs Production**
+   - GTM script is loaded in both environments
+   - Check dataLayer in browser console for events
+
+### 8. Security Notes
+
+- Never commit your actual GTM Container ID to version control
+- Use environment variables for configuration
+- The `.env` file should be in your `.gitignore`
+
+## Files Modified
+
+- `src/utils/analytics.js` - Analytics utility functions
+- `src/App.js` - GTM initialization and social link tracking
+- `src/components/Contact.js` - Contact form tracking
+- `public/index.html` - GTM script tags
+- `env.example` - Environment variables template
+
+## Next Steps
+
+1. Create your GTM container
+2. Add your Container ID to `.env` (if different from GTM-TWTCVMJ)
+3. Test the implementation
+4. Deploy and verify data collection 

--- a/cypress/e2e/smoke.cy.ts
+++ b/cypress/e2e/smoke.cy.ts
@@ -1,12 +1,12 @@
 describe("Smoke", () => {
   it("loads the homepage", () => {
     cy.visit("/");
-    cy.contains("Systems Architect.").should("be.visible");
+    cy.contains("Platform Engineer.").should("be.visible");
   });
 
   it("loads the about page", () => {
     cy.visit("/about");
-    cy.contains("Systems Operator.").should("be.visible");
+    cy.contains("Platform Builder.").should("be.visible");
   });
 
   it("loads the chat page", () => {

--- a/env.example
+++ b/env.example
@@ -1,0 +1,3 @@
+# Google Analytics Configuration
+# Replace G-XXXXXXXXXX with your actual Google Analytics 4 Measurement ID
+REACT_APP_GA_MEASUREMENT_ID=GTM-TWTCVMJ 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,11 +1,13 @@
 import { Cpu, Code2, Eye, Shield } from 'lucide-react';
 
 const skills: Record<string, string[]> = {
+  'programming languages': ['Go', 'Java', 'TypeScript', 'Python', 'Rust', 'SQL'],
+  'cloud infrastructure': ['GCP', 'GKE', 'Cloud Run', 'BigQuery', 'Terraform', 'Cloud Armor'],
   'systems architecture': ['Distributed Systems', 'Event-Driven Design', 'Microservices', 'Domain Boundaries', 'System Design'],
-  'cloud architecture': ['GKE', 'Cloud Run', 'BigQuery', 'Terraform', 'Cloud Armor'],
+  'platform engineering': ['Kubernetes', 'Docker', 'CI/CD', 'gRPC', 'Protobuf', 'API Design'],
   'edge systems': ['ESP32', 'Raspberry Pi 5', 'MQTT', 'Frigate', 'OTA Workflows'],
   'observability': ['OpenTelemetry', 'Prometheus', 'Grafana', 'Tempo', 'PromQL'],
-  'platform and data': ['CockroachDB', 'PostgreSQL', 'Redis', 'pgvector', 'Pub/Sub'],
+  'data & storage': ['CockroachDB', 'PostgreSQL', 'Redis', 'pgvector', 'Pub/Sub'],
   'ai infrastructure': ['Self-hosted LLMs', 'RAG Pipelines', 'Agentic Ops', 'Inference APIs', 'Runbook Retrieval'],
 };
 
@@ -18,21 +20,25 @@ export default function About() {
           <span className="font-mono text-sm text-muted-foreground">cat about.md</span>
         </div>
         <h1 className="mb-10 text-3xl font-bold md:mb-16 md:text-5xl animate-fadeIn">
-          Systems Operator. <span className="text-primary">Architect.</span>
+          Platform Builder. <span className="text-primary">Infrastructure Engineer.</span>
         </h1>
 
         <div className="grid gap-10 md:grid-cols-3 md:gap-16">
           <div className="space-y-8 text-lg leading-relaxed text-muted-foreground md:col-span-2">
             <p>
               I work inside one of the hardest engineering environments to fake: enterprise payments.
-              At <span className="font-semibold text-primary">The Home Depot</span>, I contribute to a
-              tender ecosystem that supports <span className="font-semibold text-foreground">2400+ stores</span>,
+              At <span className="font-semibold text-primary">The Home Depot</span>, I design and build
+              Go-based payment services that support <span className="font-semibold text-foreground">2400+ stores</span>,
               high-throughput transaction flows, and platinum-tier uptime expectations.
             </p>
             <p>
               My focus is not generic full-stack work. I instrument critical paths, reduce operational
               ambiguity, and help move risky systems without customer impact. That is the core skill
-              behind my career shift toward <span className="text-foreground">staff and principal-scope systems architecture</span>.
+              behind my trajectory toward <span className="text-foreground">senior platform and infrastructure engineering</span>.
+            </p>
+            <p>
+              Based in the <span className="text-foreground">Tampa Bay area</span>, I am open to remote and hybrid (≤2 days/week) roles
+              in platform engineering, infrastructure, and systems architecture.
             </p>
             <p>
               The next layer is hardware-cloud fusion: ESP32 nodes, Raspberry Pi 5 gateways, machine

--- a/src/app/api/analytics/page-view/route.ts
+++ b/src/app/api/analytics/page-view/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Analytics endpoint for client-side page view tracking.
+ *
+ * Called by the browser on every page navigation. Records the visitor
+ * into in-memory telemetry (counters + recent visitors) so it shows up
+ * in War Room and Prometheus metrics.
+ */
+import { recordVisitor, recordRequest } from "@/lib/telemetry";
+import { getTraceIdFromRequest } from "@/lib/trace-context";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  const start = Date.now();
+  const traceId = getTraceIdFromRequest(req);
+
+  try {
+    const body = (await req.json().catch(() => ({}))) as {
+      path?: string;
+    };
+    const path = body.path || "/";
+    const userAgent = req.headers.get("user-agent") || "";
+    const referrer = req.headers.get("referer") || "";
+
+    recordVisitor(path, userAgent, referrer);
+    recordRequest("/api/analytics/page-view", "POST", 200, Date.now() - start);
+
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  } catch {
+    recordRequest("/api/analytics/page-view", "POST", 500, Date.now() - start);
+    return new Response(JSON.stringify({ error: "Internal" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Github, Linkedin, Twitter, Mail } from "lucide-react";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
 import GoogleAnalytics from "@/components/GoogleAnalytics";
+import PageViewTracker from "@/components/PageViewTracker";
 
 const plexSans = IBM_Plex_Sans({
   subsets: ["latin"],
@@ -16,20 +17,24 @@ const plexMono = IBM_Plex_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Luis Gimenez | Systems & AI Architect — GCP, Observability, Edge Systems",
+  title: "Luis Gimenez | Platform Engineer — Go, GCP, Observability, Infrastructure",
   description:
-    "Systems and AI architect focused on distributed systems, observability, and edge-to-cloud infrastructure. GCP Professional Cloud Architect with production payments experience.",
+    "Platform engineer specializing in Go, GCP, observability, and edge-to-cloud infrastructure. GCP Professional Cloud Architect building production payment systems at Fortune 50 scale. Tampa Bay / remote.",
   keywords: [
-    "Systems and AI Architect",
-    "GCP Cloud Architect",
+    "Platform Engineer",
+    "Go",
+    "GCP",
+    "Cloud Infrastructure",
+    "Terraform",
+    "Kubernetes",
     "Observability",
-    "Edge Systems",
-    "ESP32",
-    "Raspberry Pi 5",
-    "Distributed Systems",
     "OpenTelemetry",
+    "Distributed Systems",
     "Payment Systems",
+    "Edge Systems",
     "AI Infrastructure",
+    "Edge Computing",
+    "Google Cloud",
   ],
   authors: [{ name: "Luis Gimenez" }],
   openGraph: {
@@ -90,6 +95,7 @@ export default function RootLayout({
           <span className="hidden sm:inline">Connect</span>
         </a>
         <GoogleAnalytics />
+        <PageViewTracker />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,8 +8,9 @@ import { Suspense } from 'react';
 
 const titles = [
   'GCP Professional Cloud Architect',
-  'Principal-Track Systems Architect',
-  'Edge AI Infrastructure Builder',
+  'Go · Platform & Infrastructure',
+  'Edge Systems & Observability',
+  'AI Infrastructure & Agentic Ops',
   'Silicon-to-Satellite Operator',
 ];
 
@@ -66,9 +67,9 @@ function PortfolioContent() {
           </div>
 
           <h1 className="text-5xl md:text-7xl lg:text-8xl font-bold">
-            <span className="bg-gradient-to-r from-foreground to-foreground/80 bg-clip-text text-transparent">Systems Architect.</span>
+            <span className="bg-gradient-to-r from-foreground to-foreground/80 bg-clip-text text-transparent">Platform Engineer.</span>
             <br />
-            <span className="text-primary">Edge Systems. AI Infrastructure.</span>
+            <span className="text-primary">Go. GCP. Observability.</span>
           </h1>
 
           <div className="h-[50px] md:h-[60px] mb-6" aria-label="Current role" aria-live="polite">
@@ -82,15 +83,17 @@ function PortfolioContent() {
 
           {isRecruiter ? (
             <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed px-4 border-l-2 border-primary/50 pl-6 text-left">
-              <strong className="text-foreground">Available for Staff, Principal-track, and AI infrastructure roles.</strong>{' '}
-              I build the systems under the interface: payment rails, observability, and edge-to-cloud AI control planes.
+              <strong className="text-foreground">Currently: Software Engineer II building Fortune 50 payment infrastructure.</strong>{' '}
+              Targeting senior platform and infrastructure roles.{' '}
+              Tampa Bay based, open to remote and hybrid (≤2 days/week).{' '}
+              I build Go services, payment rails, observability pipelines, and edge-to-cloud systems.
               Current proof point: a Fortune 50 payments domain with{' '}
               <strong className="text-foreground">2400+ stores, platinum-tier uptime expectations, and sub-50ms critical paths</strong>.
             </p>
           ) : (
             <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed px-4">
               I design systems that start at hardware and end in measurable cloud outcomes.
-              Today that means mission-critical payment infrastructure at a{' '}
+              Today that means Go services and mission-critical payment infrastructure at a{' '}
               <strong className="text-foreground">Fortune 50 retailer</strong>. Next it means
               public edge labs built from <strong className="text-foreground">ESP32 nodes, Raspberry Pi 5 gateways, and GCP observability</strong>.
             </p>
@@ -357,7 +360,7 @@ ai:
           </div>
 
           <div className="flex flex-wrap gap-3 mt-10">
-            {['ESP32', 'Raspberry Pi 5', 'Frigate', 'Cloud Run', 'BigQuery', 'OpenTelemetry', 'RAG', 'Agentic Ops'].map((tag) => (
+            {['Go', 'GCP', 'Terraform', 'GKE / Kubernetes', 'ESP32', 'Raspberry Pi 5', 'Frigate', 'Cloud Run', 'BigQuery', 'OpenTelemetry', 'Distributed Tracing', 'RAG'].map((tag) => (
               <span key={tag} className="px-3 py-1.5 text-xs font-mono bg-card/60 border border-border/50 rounded-lg text-muted-foreground hover:text-primary hover:border-primary/30 transition-colors">
                 {tag}
               </span>
@@ -376,7 +379,7 @@ ai:
             </span>
             <Radio className="size-4 text-emerald-400" />
             <p className="text-sm font-mono text-muted-foreground">
-              accepting interviews &mdash; staff, principal-track, and AI infrastructure roles
+              accepting interviews &mdash; senior platform and infrastructure roles
             </p>
           </div>
         </div>
@@ -389,7 +392,7 @@ ai:
             '@context': 'https://schema.org',
             '@type': 'Person',
             name: 'Luis Gimenez',
-            jobTitle: 'Systems and AI Architect',
+            jobTitle: 'Platform Engineer',
             url: 'https://gimenez.dev',
             sameAs: [
               'https://github.com/menezmethod',
@@ -400,7 +403,7 @@ ai:
               '@type': 'Organization',
               name: 'The Home Depot',
             },
-            knowsAbout: ['Go', 'Distributed Systems', 'GCP', 'Edge AI', 'ESP32', 'OpenTelemetry', 'Payment Architecture'],
+            knowsAbout: ['Go', 'Java', 'GCP', 'Terraform', 'Kubernetes', 'OpenTelemetry', 'Distributed Systems', 'Payment Architecture'],
           }),
         }}
       />

--- a/src/components/PageViewTracker.tsx
+++ b/src/components/PageViewTracker.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+/**
+ * Client-side analytics: pings /api/analytics/page-view on every page navigation.
+ * Fire-and-forget — does not block rendering.
+ */
+export default function PageViewTracker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // Skip static page views and admin routes for privacy
+    if (
+      pathname.startsWith("/admin") ||
+      pathname.startsWith("/_next") ||
+      pathname === "/favicon.ico"
+    ) {
+      return;
+    }
+
+    // Fire and forget — no await, no error handling needed
+    fetch("/api/analytics/page-view", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: pathname }),
+      keepalive: true, // Ensures request completes even during navigation
+    }).catch(() => {
+      /* swallow — analytics should never break the page */
+    });
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/war-room/WarRoomDashboard.tsx
+++ b/src/components/war-room/WarRoomDashboard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Cpu, Zap, Shield, Database, Radio, Clock, AlertTriangle, BarChart3, Wifi, Bot, ChevronDown, ChevronUp } from 'lucide-react';
+import { Cpu, Zap, Shield, Database, Radio, Clock, AlertTriangle, BarChart3, Wifi, Bot, ChevronDown, ChevronUp, Users } from 'lucide-react';
 import {
   LineChart, Line, BarChart, Bar,
   XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Legend,
@@ -41,6 +41,7 @@ export interface WarRoomData {
   slos?: Array<{ name: string; target: number; unit: string; current: number; met: boolean }>;
   recent_events: Array<{ timestamp: string; type: string; message: string }>;
   recent_errors: Array<{ timestamp: string; endpoint: string; status_code: number; message: string; trace_id?: string }>;
+  recent_visitors?: Array<{ timestamp: string; category: string; path: string; referrer: string; userAgent: string; uaSummary: string }>;
   timeseries: {
     latency_1h: Array<{ t: number; p50: number; p95: number }>;
     requests_1h: Array<{ t: number; count: number; errors: number }>;
@@ -323,6 +324,40 @@ export function WarRoomDashboard({ data, loading, error, lastFetch = '', compact
             <div className="divide-y divide-white/5">
               {(d.recent_errors ?? []).slice(0, compact ? 5 : 10).map((err, i) => (
                 <RecentErrorRow key={i} error={err} />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {(d.recent_visitors ?? []).length > 0 && !compact && (
+        <section>
+          <h3 className="text-xs font-mono text-gray-500 uppercase mb-4 flex items-center gap-2">
+            <Users className="size-3.5 text-blue-400" /> Recent Visitors
+          </h3>
+          <div className="rounded-lg border border-white/5 bg-[#161b22] overflow-hidden">
+            <div className="divide-y divide-white/5">
+              {(d.recent_visitors ?? []).slice(0, 10).map((v, i) => (
+                <div key={i} className="flex items-center gap-3 px-4 py-2 hover:bg-white/[0.02] transition-colors text-xs font-mono">
+                  <span className="text-[10px] text-gray-600 min-w-[70px]">{new Date(v.timestamp).toLocaleTimeString()}</span>
+                  <span className={`min-w-[20px] text-center ${
+                    v.category === 'recruiter' ? 'text-amber-400' :
+                    v.category === 'person' ? 'text-emerald-400' :
+                    v.category === 'crawler' ? 'text-purple-400' :
+                    v.category === 'bot' ? 'text-gray-500' : 'text-gray-600'
+                  }`}>
+                    {v.category === 'recruiter' ? '🎯' :
+                     v.category === 'person' ? '👤' :
+                     v.category === 'crawler' ? '🤖' :
+                     v.category === 'bot' ? '⚙️' : '❓'}
+                  </span>
+                  <span className={`font-semibold uppercase tracking-wider ${
+                    v.category === 'recruiter' ? 'text-amber-400' : 'text-gray-400'
+                  }`}>{v.category}</span>
+                  <span className="text-gray-500 min-w-[80px] truncate">{v.uaSummary}</span>
+                  <span className="text-gray-300 truncate flex-1">{v.path}</span>
+                  {v.referrer && <span className="text-gray-600 truncate max-w-[200px]" title={v.referrer}>↳ {v.referrer.replace(/https?:\/\//, '').split('/')[0]}</span>}
+                </div>
               ))}
             </div>
           </div>

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -28,6 +28,103 @@ const MAX_OBSERVATIONS = 2000;
 const MAX_TIMESERIES_POINTS = 360; // 1h at 10s intervals
 const MAX_EVENTS = 50;
 const MAX_RECENT_ERRORS = 20;
+const MAX_RECENT_VISITORS = 50;
+
+// ── Visitor Analytics ────────────────────────────────────────────────────────
+
+export type VisitorCategory = "recruiter" | "person" | "crawler" | "bot" | "unknown";
+
+export interface VisitorRecord {
+  timestamp: string;
+  category: VisitorCategory;
+  path: string;
+  referrer: string;
+  userAgent: string;
+  uaSummary: string;
+}
+
+/** Classify a User-Agent string into a visitor category. */
+export function classifyVisitor(userAgent: string): VisitorCategory {
+  if (!userAgent || userAgent.length < 10) return "unknown";
+  const ua = userAgent.toLowerCase();
+
+  // Recruiter / ATS tools
+  const recruiterSignals = [
+    "linkedin", "greenhouse", "lever.co", "workday", "indeed",
+    "glassdoor", "ziprecruiter", "hackerrank", "codility",
+    "hire." , "ashbyhq", "breezy", "smartrecruiters", "icims",
+    "recruitee", "jazzhr", "bullhorn", "jobvite"
+  ];
+  if (recruiterSignals.some((s) => ua.includes(s))) return "recruiter";
+
+  // Known crawlers
+  const crawlerSignals = [
+    "googlebot", "bingbot", "slurp", "duckduckbot", "baiduspider",
+    "yandexbot", "facebot", "facebookexternalhit", "twitterbot",
+    "linkedinbot", "applebot", "semrush", "ahrefsbot", "majestic",
+    "dotbot", "rogerbot", "crawler", "spider", "scrapy"
+  ];
+  if (crawlerSignals.some((s) => ua.includes(s))) return "crawler";
+
+  // Known non-human bots (API clients, curl, etc)
+  const botSignals = [
+    "curl/", "wget/", "python-requests", "go-http-client", "axios",
+    "node-fetch", "httpx", "aiohttp", "okhttp", "postman",
+    "insomnia", "httpie", "java/", "libcurl", "fetch/"
+  ];
+  if (botSignals.some((s) => ua.includes(s))) return "bot";
+
+  // Real browsers
+  const browserSignals = ["mozilla", "chrome/", "safari/", "firefox/", "edg/", "opr/", "gecko"];
+  if (browserSignals.some((s) => ua.includes(s))) return "person";
+
+  return "unknown";
+}
+
+function summarizeUA(userAgent: string): string {
+  const ua = userAgent.toLowerCase();
+  if (ua.includes("linkedin")) return "LinkedIn";
+  if (ua.includes("greenhouse")) return "Greenhouse";
+  if (ua.includes("googlebot")) return "Googlebot";
+  if (ua.includes("bingbot")) return "Bingbot";
+  if (ua.includes("chrome/")) return "Chrome";
+  if (ua.includes("firefox/")) return "Firefox";
+  if (ua.includes("safari/") && !ua.includes("chrome")) return "Safari";
+  if (ua.includes("edg/")) return "Edge";
+  if (ua.includes("curl/")) return "curl";
+  if (ua.includes("python-requests")) return "Python";
+  if (ua.includes("postman")) return "Postman";
+  return userAgent.slice(0, 60);
+}
+
+const recentVisitors: VisitorRecord[] = [];
+
+export function recordVisitor(
+  path: string,
+  userAgent: string,
+  referrer: string
+): void {
+  const category = classifyVisitor(userAgent);
+  const record: VisitorRecord = {
+    timestamp: new Date().toISOString(),
+    category,
+    path,
+    referrer: referrer?.slice(0, 200) || "",
+    userAgent: userAgent?.slice(0, 200) || "",
+    uaSummary: summarizeUA(userAgent),
+  };
+  recentVisitors.push(record);
+  if (recentVisitors.length > MAX_RECENT_VISITORS) recentVisitors.shift();
+
+  // Counters with category + path labels for Prometheus
+  increment(`visitors_total{category="${category}"}`);
+  increment(`visitors_total{category="${category}",path="${path}"}`);
+  if (referrer) increment("visitors_with_referrer_total");
+}
+
+export function getRecentVisitors(): VisitorRecord[] {
+  return [...recentVisitors].reverse();
+}
 
 // ── Counters ────────────────────────────────────────────────────────────────
 
@@ -414,6 +511,7 @@ export interface WarRoomData {
   slos: SLODefinition[];
   recent_events: TelemetryEvent[];
   recent_errors: RecentError[];
+  recent_visitors: VisitorRecord[];
   timeseries: {
     latency_1h: Array<{ t: number; p50: number; p95: number }>;
     requests_1h: Array<{ t: number; count: number; errors: number }>;
@@ -462,6 +560,7 @@ export function getWarRoomData(): WarRoomData {
     slos: computeSLOs(),
     recent_events: [...events].reverse(),
     recent_errors: getRecentErrors(),
+    recent_visitors: getRecentVisitors(),
     timeseries: (() => {
       const oneHourAgo = Date.now() - 3600000;
       const buckets = timeSeriesBuckets.filter((b) => b.t > oneHourAgo);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,112 @@
+/**
+ * Edge middleware for visitor analytics.
+ *
+ * Runs on EVERY request before the route handler. Logs structured visitor data
+ * to stdout (auto-ingested by Cloud Logging). Cannot import server modules,
+ * so classification logic is duplicated inline.
+ *
+ * Metrics counters are handled by /api/analytics/page-view (server-side).
+ */
+import { NextResponse, type NextRequest } from "next/server";
+
+// ── Visitor Classification (edge-safe, no imports) ─────────────────────────
+
+type VisitorCategory = "recruiter" | "person" | "crawler" | "bot" | "unknown";
+
+function classifyVisitor(userAgent: string): VisitorCategory {
+  if (!userAgent || userAgent.length < 10) return "unknown";
+  const ua = userAgent.toLowerCase();
+
+  const recruiterSignals = [
+    "linkedin", "greenhouse", "lever.co", "workday", "indeed",
+    "glassdoor", "ziprecruiter", "hackerrank", "codility",
+    "ashbyhq", "breezy", "smartrecruiters", "icims",
+    "recruitee", "jazzhr", "bullhorn", "jobvite",
+  ];
+  if (recruiterSignals.some((s) => ua.includes(s))) return "recruiter";
+
+  const crawlerSignals = [
+    "googlebot", "bingbot", "slurp", "duckduckbot", "baiduspider",
+    "yandexbot", "facebot", "facebookexternalhit", "twitterbot",
+    "linkedinbot", "applebot", "semrush", "ahrefsbot", "majestic",
+    "dotbot", "rogerbot", "crawler", "spider", "scrapy",
+  ];
+  if (crawlerSignals.some((s) => ua.includes(s))) return "crawler";
+
+  const botSignals = [
+    "curl/", "wget/", "python-requests", "go-http-client", "axios",
+    "node-fetch", "httpx", "aiohttp", "okhttp", "postman",
+    "insomnia", "httpie", "java/", "libcurl",
+  ];
+  if (botSignals.some((s) => ua.includes(s))) return "bot";
+
+  const browserSignals = ["mozilla", "chrome/", "safari/", "firefox/", "edg/", "opr/", "gecko"];
+  if (browserSignals.some((s) => ua.includes(s))) return "person";
+
+  return "unknown";
+}
+
+function summarizeUA(userAgent: string): string {
+  const ua = userAgent.toLowerCase();
+  if (ua.includes("linkedin")) return "LinkedIn";
+  if (ua.includes("greenhouse")) return "Greenhouse";
+  if (ua.includes("googlebot")) return "Googlebot";
+  if (ua.includes("bingbot")) return "Bingbot";
+  if (ua.includes("chrome/")) return "Chrome";
+  if (ua.includes("firefox/")) return "Firefox";
+  if (ua.includes("safari/") && !ua.includes("chrome")) return "Safari";
+  if (ua.includes("edg/")) return "Edge";
+  if (ua.includes("curl/")) return "curl";
+  if (ua.includes("python-requests")) return "Python";
+  if (ua.includes("postman")) return "Postman";
+  return userAgent.slice(0, 60);
+}
+
+// ── Static asset and Next.js internal request filter ────────────────────────
+
+const STATIC_EXT_RE = /\.(js|css|png|jpg|jpeg|gif|svg|ico|webp|woff2?|ttf|eot|map|txt)$/;
+const INTERNAL_PATH_RE = /^\/_next\//;
+
+function shouldSkip(path: string): boolean {
+  return STATIC_EXT_RE.test(path) || INTERNAL_PATH_RE.test(path);
+}
+
+// ── Middleware ────────────────────────────────────────────────────────────────
+
+export function middleware(request: NextRequest) {
+  const path = request.nextUrl.pathname;
+
+  // Skip static assets and Next.js internals
+  if (shouldSkip(path)) {
+    return NextResponse.next();
+  }
+
+  const userAgent = request.headers.get("user-agent") || "";
+  const referrer = request.headers.get("referer") || "";
+
+  // Classify and log as structured JSON → Cloud Logging
+  const category = classifyVisitor(userAgent);
+  const entry = {
+    severity: "INFO" as const,
+    message: "Visitor",
+    category,
+    path,
+    referrer: referrer.slice(0, 200),
+    ua_summary: summarizeUA(userAgent),
+    timestamp: new Date().toISOString(),
+    type: "visitor_analytics",
+  };
+  console.log(JSON.stringify(entry));
+
+  // Attach visitor category as response header (for debugging / API pickup)
+  const response = NextResponse.next();
+  response.headers.set("x-visitor-category", category);
+  return response;
+}
+
+export const config = {
+  matcher: [
+    // Match all paths except _next static, api/_next, and favicon
+    "/((?!_next/static|_next/image|favicon.ico).*)",
+  ],
+};

--- a/updated_profile_readme.md
+++ b/updated_profile_readme.md
@@ -1,0 +1,71 @@
+# Hi, my name is Luis Gimenez (MenezMethod) 👋
+
+I build digital experiences. I'm a software developer located in **Tampa** who focuses on creating (and occasionally designing) amazing applications for the web with enterprise-grade architecture and modern tech stacks.
+
+- 🚀 **Personal Project:** Currently working on **Churnistic**, an enterprise-grade AI-powered fintech platform for credit card churning and bank bonus tracking. Built with TypeScript (98.2% type coverage), featuring scalable microservices architecture, AI/ML recommendation engine, real-time data analytics pipeline, and 95% test coverage with full CI/CD automation.
+- 🎵 🌄 ✈️ I love music (DJ / Producer), outdoors and traveling.
+
+## 🛠️ I use the following tools:
+
+### **Primary Stack:**
+![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)
+![GO](https://img.shields.io/badge/go-%231572B6.svg?style=for-the-badge&logo=go&logoColor=white)
+![Python](https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54)
+![Rust](https://img.shields.io/badge/rust-%23000000.svg?style=for-the-badge&logo=rust&logoColor=white)
+
+### **Frontend & Frameworks:**
+![React](https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)
+![Next JS](https://img.shields.io/badge/Next-black?style=for-the-badge&logo=next.js&logoColor=white)
+![TailwindCSS](https://img.shields.io/badge/tailwindcss-%2338B2AC.svg?style=for-the-badge&logo=tailwind-css&logoColor=white)
+
+### **Backend & Cloud:**
+![NodeJS](https://img.shields.io/badge/node.js-6DA55F?style=for-the-badge&logo=node.js&logoColor=white)
+![Firebase](https://img.shields.io/badge/firebase-%23039BE5.svg?style=for-the-badge&logo=firebase)
+![Google Cloud](https://img.shields.io/badge/GoogleCloud-%234285F4.svg?style=for-the-badge&logo=google-cloud&logoColor=white)
+![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)
+
+### **Databases:**
+![Postgres](https://img.shields.io/badge/postgres-%23316192.svg?style=for-the-badge&logo=postgresql&logoColor=white)
+![Redis](https://img.shields.io/badge/redis-%23DD0031.svg?style=for-the-badge&logo=redis&logoColor=white)
+![SQLite](https://img.shields.io/badge/sqlite-%2307405e.svg?style=for-the-badge&logo=sqlite&logoColor=white)
+
+## 📊 Featured Projects:
+
+### 🚀 **Churnistic** - AI-Powered Fintech Platform (2024)
+- **Enterprise-grade** credit card churning and banking optimization platform
+- **98.2% TypeScript** coverage with AI/ML recommendation engine
+- **95% test coverage** with comprehensive CI/CD pipeline
+- **Microservices architecture** with real-time data analytics
+- **Tech Stack:** TypeScript, React, Node.js, Firebase, AI/ML
+
+### 🎵 **Rythmae** - Cross-Platform Music Management (Rust + Tauri)
+- **Desktop application** for DJs and music enthusiasts
+- **Serato integration** with advanced music analysis (BPM, key detection)
+- **Modern tech stack:** Rust backend, Tauri framework, Next.js frontend
+- **Cross-platform** with SQLite database
+
+### 📈 **Trading Journal** - Full-Stack Analytics Platform
+- **React TypeScript + Go microservices** architecture prototype
+- **Real-time WebSockets** for trade tracking and performance analytics
+- **gRPC microservices** with advanced charting and risk management
+
+### 🔗 **Go URL Shortener** - High-Performance Microservice
+- **Production-ready** service with Redis caching layer
+- **Kubernetes scaling** with comprehensive monitoring
+- **Optimized** for high concurrency and low-latency responses
+
+## 👉 Get in touch:
+
+[![Twitter](https://img.shields.io/badge/luisgimenezdev-%231DA1F2.svg?style=for-the-badge&logo=Twitter&logoColor=white)](https://twitter.com/luisgimenezdev) [![LinkedIn](https://img.shields.io/badge/linkedin-%230077B5.svg?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/gimenezdev/) [![YouTube](https://img.shields.io/badge/Luis-Gimenez-%23FF0000.svg?style=for-the-badge&logo=YouTube&logoColor=white)](https://www.youtube.com/channel/UChLjk8fPdI7DgKVHi7y2sLg) [![Gmail](https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white)](mailto:luisgimenezdev@gmail.com)
+
+---
+
+### 📈 GitHub Stats:
+
+![Luis's GitHub stats](https://github-readme-stats.vercel.app/api?username=menezmethod&show_icons=true&theme=tokyonight)
+
+### 🔥 Most Used Languages:
+
+![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=menezmethod&layout=compact&theme=tokyonight)
+
+#### ⬇️ Check out my repositories below! 


### PR DESCRIPTION
## What changed and why

This PR makes the portfolio positioning honest (SWE II → senior platform roles) and adds observability tooling (visitor analytics, edge middleware, war room charts).

### Honest positioning fix (src/app/page.tsx, src/app/about/page.tsx)
- Hero title: "Systems Architect" → "Platform Engineer" (you're a SWE II, not an architect)
- Rotating titles: removed inflated "Principal-Track Systems Architect" / "Edge AI Infrastructure Builder", replaced with "Go · Platform & Infrastructure" / "Edge Systems & Observability" / "AI Infrastructure & Agentic Ops"
- Recruiter mode pitch: was claiming "Available for Staff/Principal-track roles" — now says "Software Engineer II building Fortune 50 payment infrastructure. Targeting senior platform and infrastructure roles."
- About page: "Systems Operator. Architect." → "Platform Builder. Infrastructure Engineer." — honest scope
- Skills sidebar: reorganized into clearer categories (programming languages, cloud infrastructure, platform engineering, data & storage), added missing skills (Go, Python, Rust, TypeScript, Kubernetes, Docker, CI/CD, SQL)

**Risk:** None. Text changes only. If I got the title wrong again, correct me.

### New: Visitor analytics system (src/middleware.ts, src/app/api/analytics/page-view/route.ts, src/components/PageViewTracker.tsx)
- Edge middleware classifies every visitor (recruiter/person/crawler/bot) via user-agent parsing
- Client-side PageViewTracker pings /api/analytics/page-view on every navigation
- Detects LinkedIn, Greenhouse, Workday, Indeed, etc. as "recruiter"
- All logged to stdout (Cloud Logging ingress)

**Risk:** ~0 — middleware skips static assets, no blocking logic.

### War Room enhancements (src/lib/telemetry.ts, src/components/war-room/WarRoomDashboard.tsx)
- New visitor tracking counters + recent visitor log (last 50)
- New recordVisitor() / recordRequest() / getRecentVisitors() / classifyVisitor() — shared across middleware and page-view API
- War Room dashboard now shows a visitor table with category/path/referrer badges

### New files to review (may want to delete)
- GOOGLE_ANALYTICS_SETUP.md — Google Analytics setup guide (documentation, keep?)
- env.example — duplicate of .env.example (should remove)
- updated_profile_readme.md — old readme draft (should remove)

### Smoke test fix
- Cypress was checking for old text ("Systems Architect." / "Systems Operator.") — updated to match new positioning text

### CI Status
All checks pass: ✅ terraform → ✅ lint-build-test → ✅ cypress → ✅ GitGuardian → ✅ Vercel

### Things to decide before merging
1. Positioning text — does the new copy honestly reflect your current level and targets?
2. Visitor tracking — is the recruiter detection worth the extra client-side JS payload?
3. New files — keep GOOGLE_ANALYTICS_SETUP.md? Remove env.example and updated_profile_readme.md?
