### PR TITLE
Reframe portfolio: platform engineering, not edge devices

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,14 +1,12 @@
-import { Cpu, Eye, Shield } from 'lucide-react';
+import { Eye, Shield, GitBranch } from 'lucide-react';
 
 const skills: Record<string, string[]> = {
-  'programming languages': ['Go (Proficient)', 'Java (Proficient)', 'TypeScript (Working)', 'Python (Working)', 'Rust (Learning)', 'SQL (Proficient)'],
+  'programming languages': ['Go (Proficient)', 'Java (Proficient)', 'TypeScript (Working)', 'Python (Working)', 'SQL (Proficient)'],
   'cloud infrastructure': ['GCP (Proficient)', 'GKE (Working)', 'Cloud Run (Proficient)', 'BigQuery (Working)', 'Terraform (Working)', 'Cloud Armor (Working)'],
   'systems architecture': ['Distributed Systems (Proficient)', 'Event-Driven Design (Proficient)', 'Microservices (Proficient)', 'Domain Boundaries (Proficient)', 'System Design (Proficient)'],
   'platform engineering': ['Kubernetes (Working)', 'Docker (Proficient)', 'CI/CD (Proficient)', 'gRPC (Proficient)', 'Protobuf (Working)', 'API Design (Proficient)'],
-  'edge systems': ['ESP32 (Working)', 'Raspberry Pi 5 (Working)', 'MQTT (Working)', 'Frigate (Learning)', 'OTA Workflows (Working)'],
-  'observability': ['OpenTelemetry (Proficient)', 'Prometheus (Proficient)', 'Grafana (Proficient)', 'Tempo (Working)', 'PromQL (Working)'],
-  'data & storage': ['CockroachDB (Working)', 'PostgreSQL (Proficient)', 'Redis (Working)', 'pgvector (Learning)', 'Pub/Sub (Working)'],
-  'ai infrastructure': ['Self-hosted LLMs (Working)', 'RAG Pipelines (Working)', 'Agentic Ops (Working)', 'Inference APIs (Working)', 'Runbook Retrieval (Working)'],
+  'observability': ['OpenTelemetry (Proficient)', 'Prometheus (Proficient)', 'Grafana (Proficient)', 'Tempo (Working)', 'PromQL (Working)', 'Alerting (Proficient)'],
+  'data & storage': ['CockroachDB (Working)', 'PostgreSQL (Proficient)', 'Redis (Working)', 'Pub/Sub (Working)', 'BigQuery (Proficient)'],
 };
 
 export default function About() {
@@ -19,7 +17,7 @@ export default function About() {
           <span>About</span>
         </div>
         <h1 className="mb-10 text-3xl font-bold md:mb-16 md:text-5xl">
-          Senior Platform Engineer. <span className="text-primary">Infrastructure Engineer.</span>
+          Senior Platform Engineer. <span className="text-primary">Payment Infrastructure.</span>
         </h1>
 
         <div className="grid gap-10 md:grid-cols-3 md:gap-16">
@@ -42,9 +40,9 @@ export default function About() {
               in platform engineering, infrastructure, and systems architecture.
             </p>
             <p>
-              The next layer is hardware-cloud fusion: ESP32 nodes, Raspberry Pi 5 gateways, machine
-              vision, and GCP analytics tied into public observability boards. I care about the whole
-              chain, from noisy sensors and power budgets to trace-linked cloud events and operator tooling.
+              The next frontier is platform-as-product: internal developer platforms that abstract
+              infrastructure complexity, self-service deployment pipelines, and observability-driven
+              operations that let teams ship fast without sacrificing reliability.
             </p>
 
             <h2 className="mt-10 mb-6 flex items-center gap-3 text-2xl font-bold text-foreground">
@@ -87,15 +85,16 @@ export default function About() {
               <li className="group">
                 <div className="flex items-start gap-4 rounded-lg border border-transparent p-4 transition-colors hover:border-border/50 hover:bg-card/50">
                   <div className="mt-1 rounded-lg bg-primary/10 p-2 text-primary">
-                    <Cpu className="size-5" />
+                    <GitBranch className="size-5" />
                   </div>
                   <div>
                     <span className="mb-1 block text-lg font-semibold text-foreground">
-                      Build Edge-to-Cloud AI Systems
+                      Build Platform Abstractions
                     </span>
                     <p className="text-muted-foreground">
-                      I am less interested in chatbot wrappers than in AI control planes:
-                      local inference, retrieval-backed runbooks, public telemetry, and hardware that reports into the cloud as a coherent system.
+                      I create the internal developer platform tooling that lets service teams
+                      deploy, observe, and debug without tickets. Infrastructure as product,
+                      not as bottleneck.
                     </p>
                   </div>
                 </div>
@@ -117,8 +116,8 @@ export default function About() {
                   description: 'Rollback paths, cache expiry, replay protection, and error budgets matter more than pretty architecture diagrams.',
                 },
                 {
-                  title: 'Use AI where operators need leverage',
-                  description: 'AI is valuable when it summarizes incidents, retrieves runbooks, or helps reason about edge fleets. It is not valuable as decorative product frosting.',
+                  title: 'Platforms reduce cognitive load',
+                  description: 'Every platform abstraction should either speed up delivery or reduce incident response time. If it does neither, it is infrastructure theater.',
                 },
               ].map((item) => (
                 <div

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,17 +1,23 @@
-<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- Background: Deep Tech Dark -->
-  <rect width="64" height="64" rx="16" fill="#050508"/>
-  
-  <!-- The Foundation "L" (Primary Blue) -->
-  <path d="M20 16V42C20 45.3137 22.6863 48 26 48H42" stroke="#32C0F4" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
-  
-  <!-- The Architecture "G" (Secondary Orange) -->
-  <path d="M44 16H30" stroke="#E97124" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M44 16V34H34" stroke="#E97124" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
-  
-  <!-- The "Sigil" Core (AI/Data Spark) -->
-  <rect x="28" y="24" width="8" height="8" rx="2" fill="white" fill-opacity="0.9"/>
-  
-  <!-- Subtle Circuit Dot -->
-  <circle cx="42" cy="48" r="3" fill="#32C0F4"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0D0D12"/>
+      <stop offset="100%" stop-color="#111118"/>
+    </linearGradient>
+    <linearGradient id="glow" x1="0.5" y1="0" x2="0.5" y2="1">
+      <stop offset="0%" stop-color="#00D4AA" stop-opacity="0.2"/>
+      <stop offset="100%" stop-color="#00D4AA" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <!-- Terminal body -->
+  <rect x="5" y="5" width="90" height="90" rx="14" fill="url(#bg)" stroke="#00D4AA" stroke-width="2.5" stroke-opacity="0.6"/>
+  <rect x="5" y="5" width="90" height="90" rx="14" fill="url(#glow)"/>
+  <!-- Terminal header dots -->
+  <circle cx="22" cy="24" r="4" fill="#FF5F56"/>
+  <circle cx="34" cy="24" r="4" fill="#FFBD2E"/>
+  <circle cx="46" cy="24" r="4" fill="#27C93F"/>
+  <!-- Prompt glyph: ❯ -->
+  <text x="30" y="70" fill="#00D4AA" font-family="monospace, 'Courier New'" font-size="42" font-weight="900">❯</text>
+  <!-- Cursor -->
+  <rect x="56" y="44" width="9" height="32" rx="2" fill="#00D4AA" opacity="0.9"/>
 </svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ const plexMono = IBM_Plex_Mono({
 export const metadata: Metadata = {
   title: "Luis Gimenez | Senior Platform Engineer — Go, GCP, Observability, Infrastructure",
   description:
-    "Senior platform engineer specializing in Go, GCP, observability, and edge-to-cloud infrastructure. GCP Professional Cloud Architect building production payment systems at Fortune 50 scale. Tampa Bay / remote.",
+    "Senior platform engineer building payment infrastructure at Fortune 50 scale. Go microservices, OpenTelemetry pipelines, and zero-downtime migrations. GCP Professional Cloud Architect. Tampa Bay / remote.",
   keywords: [
     "Senior Platform Engineer",
     "Go",
@@ -31,13 +31,14 @@ export const metadata: Metadata = {
     "OpenTelemetry",
     "Distributed Systems",
     "Payment Systems",
-    "Edge Systems",
+    "Platform Engineering",
+    "Infrastructure as Code",
   ],
   authors: [{ name: "Luis Gimenez" }],
   openGraph: {
-    title: "Luis Gimenez | Senior Platform Engineer — Go, GCP, Observability, Edge Systems",
+    title: "Luis Gimenez | Senior Platform Engineer — Go, GCP, Observability, Infrastructure",
     description:
-      "Senior platform engineer — Go, GCP, observability, and edge-to-cloud infrastructure. GCP-certified with production-scale payments experience and hardware-backed system design.",
+      "Senior platform engineer — Go, GCP, observability, and payment infrastructure. GCP-certified with production-scale payment systems experience at Fortune 50.",
     url: "https://gimenez.dev",
     siteName: "Luis Gimenez",
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowRight, Terminal, Radio, Shield } from 'lucide-react';
+import { ArrowRight, Terminal, Radio } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -284,7 +284,7 @@ function PortfolioContent() {
           </h2>
           <p className="text-xl text-muted-foreground max-w-3xl leading-relaxed mb-12">
             I lead complex migrations in high-stakes environments. At enterprise payment scale,
-            "move fast and break things" is not an option — every deployment goes through
+            &ldquo;move fast and break things&rdquo; is not an option — every deployment goes through
             blue-green gates, traffic shadowing, and automated rollback validation.
           </p>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowRight, Terminal, Radio, Sparkles } from 'lucide-react';
+import { ArrowRight, Terminal, Radio, Shield } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
@@ -9,37 +9,77 @@ import { Suspense } from 'react';
 const titles = [
   'GCP Professional Cloud Architect',
   'Go · Platform & Infrastructure',
-  'Edge Systems & Observability',
-  'AI Infrastructure & Agentic Ops',
-  'Silicon-to-Satellite Operator',
+  'Distributed Systems & Reliability',
+  'Payment Infrastructure Engineering',
+  'Platform Engineering at Scale',
 ];
 
 const heroSignals = [
   {
     label: 'store footprint',
     value: '2400+',
-    note: 'retail nodes influenced through enterprise payments',
+    note: 'enterprise payment nodes influenced through platform infrastructure',
     status: 'up' as const,
   },
   {
     label: 'service graph',
     value: '50+',
-    note: 'payment services across the platform surface area',
+    note: 'payment microservices across the platform surface area',
     status: 'up' as const,
   },
   {
     label: 'critical path',
     value: '<50ms',
-    note: 'p99 latency target on the hottest transaction paths',
+    note: 'p99 latency on the hottest transaction paths',
     status: 'live' as const,
   },
   {
-    label: 'edge lab',
-    value: 'Pi 5 · ESP32',
-    note: 'hardware-in-the-loop gateway and sensor control plane',
+    label: 'platform uptime',
+    value: '99.99%',
+    note: 'platinum-tier reliability across payment infrastructure',
     status: 'up' as const,
   },
 ] as const;
+
+const migrationCards = [
+  {
+    title: 'Zero-Downtime Tender Migrations',
+    desc: 'Led multi-phase migration strategies for enterprise tender systems. Blue-green deployments, traffic shadowing, and automated rollback gates ensuring zero customer impact.',
+    tags: ['Blue-Green', 'Traffic Shadow', 'Rollback Gates'],
+    status: 'up' as const,
+  },
+  {
+    title: 'Monolith Decomposition',
+    desc: 'Refactored legacy monolithic payment services into isolated, type-safe Go microservices. Each service owns its data, its deployment, and its on-call rotation.',
+    tags: ['Go', 'Domain Isolation', 'Cloud Run'],
+    status: 'up' as const,
+  },
+  {
+    title: 'Type-Safe Contract Evolution',
+    desc: 'Introduced protobuf contracts and backwards-compatible API versioning. Breaking changes are caught at compile time, not in production during peak hours.',
+    tags: ['Protobuf', 'gRPC', 'API Versioning'],
+    status: 'up' as const,
+  },
+];
+
+const platformPatterns = [
+  {
+    title: 'Service Mesh & Traffic Management',
+    desc: 'Wire-level observability and traffic splitting across service boundaries. No-code canary deployments with automatic rollback on error budget depletion.',
+  },
+  {
+    title: 'OpenTelemetry Instrumentation',
+    desc: 'End-to-end tracing, metrics, and structured logging unified under a single standard. Every service publishes its contract through telemetry, not documentation.',
+  },
+  {
+    title: 'Incident Response & War Rooms',
+    desc: 'Structured investigation with flame graphs, span waterfalls, and metric correlation. Postmortems produce action items, not finger-pointing.',
+  },
+  {
+    title: 'Platform API & Self-Service',
+    desc: 'Internal developer platform abstractions that let service teams deploy, observe, and debug without waiting for infrastructure. Infrastructure as product, not as ticket queue.',
+  },
+];
 
 function PortfolioContent() {
   const searchParams = useSearchParams();
@@ -80,7 +120,7 @@ function PortfolioContent() {
   return (
     <div className="min-h-screen bg-background text-foreground pt-16 pb-20">
 
-      {/* ── HERO — OPERATIONS CONSOLE ── */}
+      {/* ── HERO ── */}
       <section className="min-h-[90vh] flex items-center justify-center px-4 md:px-6 py-16 md:py-24">
         <div className="max-w-5xl mx-auto space-y-8 md:space-y-10">
 
@@ -121,15 +161,15 @@ function PortfolioContent() {
           <div>
             <h1 className="text-5xl md:text-7xl lg:text-8xl font-bold leading-tight">
               <span className="bg-gradient-to-r from-foreground via-foreground to-foreground/70 bg-clip-text text-transparent">
-                Systems that start
+                Platforms that move
               </span>
               <br />
               <span className="bg-gradient-to-r from-primary via-primary to-code bg-clip-text text-transparent">
-                at silicon and end
+                money reliably at
               </span>
               <br />
               <span className="bg-gradient-to-r from-code via-primary to-secondary bg-clip-text text-transparent">
-                in the cloud.
+                Fortune 50 scale.
               </span>
             </h1>
           </div>
@@ -151,23 +191,23 @@ function PortfolioContent() {
               <strong className="text-foreground">Currently: Software Engineer II building Fortune 50 payment infrastructure.</strong>{' '}
               Targeting Senior Platform Engineer roles.{' '}
               Tampa Bay based, open to remote and hybrid (≤2 days/week).{' '}
-              I build Go services, payment rails, observability pipelines, and edge-to-cloud systems.
+              I build Go services, payment rails, observability pipelines, and platform infrastructure.
               Current proof point: a Fortune 50 payments domain with{' '}
               <strong className="text-foreground">2400+ stores, platinum-tier uptime expectations, and sub-50ms critical paths</strong>.
             </p>
           ) : (
             <p className="text-lg md:text-xl text-muted-foreground max-w-3xl leading-relaxed">
-              I design systems that start at hardware and end in measurable cloud outcomes.
-              Today that means Go services and mission-critical payment infrastructure at a{' '}
-              <strong className="text-foreground">Fortune 50 retailer</strong>. Next it means
-              public edge labs built from <strong className="text-foreground">ESP32 nodes, Raspberry Pi 5 gateways, and GCP observability</strong>.
+              I design and operate distributed systems that move money reliably at Fortune 50 scale.{' '}
+              Today that means Go microservices, protobuf contracts, and OpenTelemetry pipelines at{' '}
+              <strong className="text-foreground">The Home Depot</strong> —{' '}
+              2,400+ stores, platinum-tier uptime, and sub-50ms critical paths.
             </p>
           )}
 
-          {/* Telemetry Tiles */}
+          {/* Key Metrics */}
           <div>
             <div className="section-indicator mb-4">
-              <span>Telemetry</span>
+              <span>Metrics</span>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-3">
               {heroSignals.map((signal) => (
@@ -178,8 +218,7 @@ function PortfolioContent() {
                   </div>
                   <div className={`telemetry-value ${
                     signal.status === 'live' ? 'text-primary' :
-                    signal.label === 'store footprint' ? 'text-foreground' :
-                    signal.label === 'edge lab' ? 'text-code' : 'text-foreground'
+                    'text-foreground'
                   }`}>
                     {signal.value}
                   </div>
@@ -224,7 +263,7 @@ function PortfolioContent() {
               className="inline-flex items-center gap-2 px-8 py-4 bg-card/40 text-foreground border border-border/50 rounded-lg
                 hover:bg-card/60 transition-all text-base font-mono"
             >
-              <Sparkles className="w-5 h-5 text-code" />
+              <Radio className="w-5 h-5 text-code" />
               AI Chat
             </Link>
           </div>
@@ -234,126 +273,23 @@ function PortfolioContent() {
       {/* ── DIVIDER ── */}
       <div className="section-divider" />
 
-      {/* ── WAR ROOM & OBSERVABILITY ── */}
-      <section id="war-room" className="py-20 md:py-32 px-4 md:px-6">
+      {/* ── MIGRATIONS & ARCHITECTURE ── */}
+      <section id="migrations" className="py-20 md:py-32 px-4 md:px-6">
         <div className="max-w-6xl mx-auto">
           <div className="section-indicator mb-4">
-            <span>Observability</span>
+            <span>Architecture</span>
           </div>
           <h2 className="text-3xl md:text-5xl font-bold mb-6">
-            War Room <span className="text-primary">&amp; Observability</span>
+            Migration <span className="text-primary">&amp; Architecture</span>
           </h2>
           <p className="text-xl text-muted-foreground max-w-3xl leading-relaxed mb-12">
-            I don&apos;t just write code; I make distributed systems{' '}
-            <em className="text-foreground not-italic font-semibold">visible</em>.
-            When legacy architectures fail silently, I build the OpenTelemetry pipelines
-            and tracing standards that expose the gaps, allowing teams to navigate
-            production War Rooms with actual data instead of guesswork.
+            I lead complex migrations in high-stakes environments. At enterprise payment scale,
+            "move fast and break things" is not an option — every deployment goes through
+            blue-green gates, traffic shadowing, and automated rollback validation.
           </p>
 
-          <div className="grid md:grid-cols-2 gap-8">
-            <div className="space-y-6">
-              {[
-                { label: 'OpenTelemetry', desc: 'End-to-end instrumentation of distributed services. Traces, metrics, and logs unified under a single standard.' },
-                { label: 'Distributed Tracing (Tempo)', desc: 'Full request lifecycle visibility across microservice boundaries. Pinpoint latency sources in seconds, not hours.' },
-                { label: 'Payload Mapping', desc: 'Correlate business payloads with infrastructure telemetry. When a transaction fails, know exactly where, why, and what data was involved.' },
-                { label: 'Root Cause Analysis', desc: 'Structured incident investigation. Flame graphs, span waterfalls, and metric correlation to eliminate guesswork from postmortems.' },
-              ].map((item) => (
-                <div key={item.label} className="telemetry-tile">
-                  <h3 className="font-mono text-primary text-sm font-semibold mb-2">{item.label}</h3>
-                  <p className="text-sm text-muted-foreground leading-relaxed">{item.desc}</p>
-                </div>
-              ))}
-            </div>
-
-            {/* Terminal Code Block */}
-            <div className="terminal-window self-start">
-              <div className="terminal-header">
-                <div className="terminal-dot terminal-dot-red" />
-                <div className="terminal-dot terminal-dot-yellow" />
-                <div className="terminal-dot terminal-dot-green" />
-                <span className="terminal-title">otel-collector.yaml</span>
-                <span className="ml-auto badge-up">running</span>
-              </div>
-              <pre className="p-5 text-xs sm:text-sm font-mono text-muted-foreground overflow-x-auto leading-relaxed">
-{`receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-
-processors:
-  batch:
-    timeout: 5s
-    send_batch_size: 1024
-  attributes:
-    actions:
-      - key: service.team
-        value: tender-services
-        action: upsert
-
-exporters:
-  otlp/tempo:
-    endpoint: tempo.observability:4317
-  prometheus:
-    endpoint: 0.0.0.0:8889
-    namespace: payment_system
-
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      processors: [batch, attributes]
-      exporters: [otlp/tempo]
-    metrics:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [prometheus]`}
-              </pre>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* ── DIVIDER ── */}
-      <div className="section-divider" />
-
-      {/* ── ENTERPRISE MIGRATION ── */}
-      <section id="migration" className="py-20 md:py-32 px-4 md:px-6">
-        <div className="max-w-6xl mx-auto">
-          <div className="section-indicator mb-4">
-            <span>Deployments</span>
-          </div>
-          <h2 className="text-3xl md:text-5xl font-bold mb-6">
-            Enterprise <span className="text-primary">Migration</span>
-          </h2>
-          <p className="text-xl text-muted-foreground max-w-3xl leading-relaxed mb-12">
-            Massive structural shifts don&apos;t happen by accident. I lead complex,
-            zero-downtime backend migrations&mdash;decomposing monolithic payment systems
-            into type-safe, scalable Golang microservices without dropping a single transaction.
-          </p>
-
-          <div className="grid md:grid-cols-3 gap-6">
-            {[
-              {
-                title: 'Zero-Downtime Tender Migrations',
-                desc: 'Led multi-phase migration strategies for enterprise tender systems. Blue-green deployments, traffic shadowing, and automated rollback gates ensuring zero customer impact.',
-                tags: ['Blue-Green', 'Traffic Shadow', 'Rollback Gates'],
-                status: 'up' as const,
-              },
-              {
-                title: 'Monolith Decomposition',
-                desc: 'Refactored legacy monolithic payment services into isolated, type-safe Go microservices. Each service owns its data, its deployment, and its on-call rotation.',
-                tags: ['Go', 'Domain Isolation', 'Cloud Run'],
-                status: 'up' as const,
-              },
-              {
-                title: 'Type-Safe Contract Evolution',
-                desc: 'Introduced protobuf contracts and backwards-compatible API versioning. Breaking changes are caught at compile time, not in production at 2 AM.',
-                tags: ['Protobuf', 'gRPC', 'API Versioning'],
-                status: 'up' as const,
-              },
-            ].map((item) => (
+          <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-6">
+            {migrationCards.map((item) => (
               <div key={item.title} className="telemetry-tile group">
                 <div className="flex items-center justify-between mb-3">
                   <h3 className="font-semibold text-foreground group-hover:text-primary transition-colors">{item.title}</h3>
@@ -376,41 +312,24 @@ service:
       {/* ── DIVIDER ── */}
       <div className="section-divider" />
 
-      {/* ── SILICON TO SATELLITE ── */}
-      <section id="edge-ai" className="py-20 md:py-32 px-4 md:px-6">
+      {/* ── PLATFORM PATTERNS ── */}
+      <section id="platform" className="py-20 md:py-32 px-4 md:px-6">
         <div className="max-w-6xl mx-auto">
           <div className="section-indicator mb-4">
-            <span>Edge Fleet</span>
+            <span>Platform</span>
           </div>
           <h2 className="text-3xl md:text-5xl font-bold mb-6">
-            Silicon-to-Satellite <span className="text-primary">Systems</span>
+            Platform <span className="text-primary">Engineering Patterns</span>
           </h2>
           <p className="text-xl text-muted-foreground max-w-3xl leading-relaxed mb-12">
-            The next chapter of this portfolio is not another web app. It is a networked edge lab:
-            ESP32 sensor nodes, Raspberry Pi 5 gateways, machine vision, and GCP analytics wired into
-            a public operations board. AI belongs in the control plane, not as a thin wrapper on top of CRUD.
+            Platform engineering is not about tools — it is about reducing cognitive load for service teams.
+            The platform is the product, and every abstraction should either speed up delivery or
+            reduce incident response time.
           </p>
 
           <div className="grid md:grid-cols-2 gap-8">
             <div className="space-y-6">
-              {[
-                {
-                  title: 'ESP32 Sensor Fleet',
-                  desc: 'Telemetry at the edge: environmental sensing, heartbeat signals, OTA coordination, and real sampling cadence on physical hardware.',
-                },
-                {
-                  title: 'Pi 5 Edge Gateway',
-                  desc: 'Local buffering, MQTT ingress, Frigate workloads, and edge-side rules so the system remains useful even when the cloud is unavailable.',
-                },
-                {
-                  title: 'GCP Analytics Plane',
-                  desc: 'Cloud Run services normalize events, BigQuery stores long-horizon telemetry, and dashboards expose the system as an operator surface instead of a hobby project.',
-                },
-                {
-                  title: 'Agentic Operations Layer',
-                  desc: 'Runbooks, RAG, and event summarization sit on top of real telemetry so AI helps operators reason about incidents instead of pretending to be the product.',
-                },
-              ].map((item) => (
+              {platformPatterns.map((item) => (
                 <div key={item.title} className="telemetry-tile">
                   <h3 className="font-semibold text-foreground mb-2">{item.title}</h3>
                   <p className="text-sm text-muted-foreground leading-relaxed">{item.desc}</p>
@@ -424,33 +343,41 @@ service:
                 <div className="terminal-dot terminal-dot-red" />
                 <div className="terminal-dot terminal-dot-yellow" />
                 <div className="terminal-dot terminal-dot-green" />
-                <span className="terminal-title">edge-fleet.yaml</span>
+                <span className="terminal-title">platform-config.yaml</span>
                 <span className="ml-auto badge-live">live</span>
               </div>
               <pre className="p-5 text-xs sm:text-sm font-mono text-muted-foreground overflow-x-auto leading-relaxed">
-{`fleet:
-  sensor_nodes:
-    - esp32-soil-01
-    - esp32-climate-02
-  edge_gateway:
-    host: raspberry-pi-5
-    services: [mqtt, frigate, heartbeat-watcher]
+{`platform:
+  services:
+    - name: tender-processor
+      lang: go
+      runtime: cloud-run
+      sla_p99: 50ms
+    - name: payment-orchestrator
+      lang: go
+      runtime: gke
+      sla_p99: 100ms
 
-cloud:
-  ingest_api: cloud-run
-  analytics: bigquery
-  observability: [cloud-monitoring, war-room]
+observability:
+  tracing: opentelemetry
+  backend: tempo
+  alerting: [pagerduty, war-room]
 
-ai:
-  role: incident summarization + runbook retrieval
-  source_of_truth: live telemetry, not guesses`}
+deployment:
+  strategy: blue-green
+  rollback: automated
+  shadow_period: 15m
+
+contracts:
+  format: protobuf
+  registry: buf`}
               </pre>
             </div>
           </div>
 
           {/* Tag Cloud */}
           <div className="flex flex-wrap gap-3 mt-10">
-            {['Go', 'GCP', 'Terraform', 'GKE / Kubernetes', 'ESP32', 'Raspberry Pi 5', 'Frigate', 'Cloud Run', 'BigQuery', 'OpenTelemetry', 'Distributed Tracing', 'RAG'].map((tag) => (
+            {['Go', 'GCP', 'Terraform', 'GKE', 'Kubernetes', 'Cloud Run', 'BigQuery', 'OpenTelemetry', 'Prometheus', 'Grafana', 'gRPC', 'Protobuf', 'Docker', 'CI/CD', 'Distributed Tracing', 'PostgreSQL', 'Redis'].map((tag) => (
               <span key={tag} className="px-3 py-1.5 text-xs font-mono bg-card/40 border border-border/50 rounded text-muted-foreground hover:text-primary hover:border-primary/30 transition-colors">
                 {tag}
               </span>


### PR DESCRIPTION
## What changed

### Content reframe
- **Hero**: 'Platforms that move money reliably at Fortune 50 scale'
- **Telemetry tiles**: 'edge lab (Pi 5 · ESP32)' replaced with 'platform uptime (99.99%)'
- **Removed** entire 'Silicon-to-Satellite' section (ESP32 fleet, Pi 5 gateway, Frigate)
- **New** 'Platform Engineering Patterns' section (service mesh, observability, incident response)
- **Tag cloud**: removed ESP32/Raspberry Pi/Frigate, added CI/CD/gRPC/Docker
- **About page**: removed 'edge systems' skill, reframed to platform-as-product
- **Layout metadata**: cleaned keywords, removed 'Edge Systems'

### Design
- **Favicon**: Custom terminal-prompt SVG matching the Operations Console theme