### PR TITLE
fix: loosen chat rate limits for usable demos

### DIFF
--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -12,7 +12,7 @@ describe("rate-limit", () => {
     it("allows first request and decrements remaining", () => {
       const r = checkRateLimit("1.2.3.4");
       expect(r.allowed).toBe(true);
-      expect(r.remaining).toBeLessThanOrEqual(1);
+      expect(r.remaining).toBeLessThanOrEqual(5);
     });
 
     it("allows then denies when window exhausted", () => {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -85,7 +85,7 @@ export function checkRateLimit(ip: string): RateLimitResult {
 
   const now = Date.now();
   const windowMs = 60 * 1000;
-  const maxRequests = parseInt(process.env.CHAT_MAX_RPM_PER_IP || "2");
+  const maxRequests = parseInt(process.env.CHAT_MAX_RPM_PER_IP || "6");
 
   const existing = ipRateLimits.get(ip);
 
@@ -188,7 +188,7 @@ export function incrementSessionMessageCount(): number {
 export function isSessionLimitReached(): boolean {
   if (RATE_LIMITS_DISABLED) return false;
   const maxMessages = parseInt(
-    process.env.NEXT_PUBLIC_CHAT_MAX_MESSAGES || "10"
+    process.env.NEXT_PUBLIC_CHAT_MAX_MESSAGES || "30"
   );
   return getSessionMessageCount() >= maxMessages;
 }


### PR DESCRIPTION
Chat was rate-limiting after 2 requests per minute and 10 messages per session.
- RPM: 2 → 6 (lets recruiters have an actual conversation)
- Session: 10 → 30 (enough for a meaningful demo)
- Daily budget stays at 150