### PR TITLE
fix: extract post data to shared module for Vercel serverless compat

### DIFF
--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -1,18 +1,9 @@
-import fs from "fs";
-import path from "path";
-import matter from "gray-matter";
-import { notFound } from "next/navigation";
-import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 import { ArrowLeft, Calendar } from "lucide-react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
 import type { Components } from "react-markdown";
-
-function getPost(slug: string) {
-  const fp = path.join(process.cwd(), "src/content/posts", slug + ".md");
-  if (!fs.existsSync(fp)) return null;
-  const { data, content } = matter(fs.readFileSync(fp, "utf-8"));
-  return { title: data.title || "Untitled", description: data.description || "", date: data.date || "", tags: (data.tags || []) as string[], content };
-}
+import { getPostBySlug, getPostSlugs } from "@/lib/posts-data";
 
 const markdownComponents: Partial<Components> = {
   code({ className, children, ...props }) {
@@ -25,7 +16,7 @@ const markdownComponents: Partial<Components> = {
 };
 
 export default function Page({ params }: { params: { slug: string } }) {
-  const post = getPost(params.slug);
+  const post = getPostBySlug(params.slug);
   if (!post) notFound();
   return (
     <article className="mx-auto max-w-3xl px-4 pt-32 pb-24">
@@ -33,7 +24,7 @@ export default function Page({ params }: { params: { slug: string } }) {
       <header className="mb-10">
         <div className="flex items-center gap-4 text-sm text-muted-foreground mb-4">
           <span><Calendar className="size-3.5 inline mr-1" />{new Date(post.date).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}</span>
-          {(post.tags as string[]).map(t => <span key={t} className="text-xs font-mono bg-primary/10 text-primary px-2 py-0.5 rounded">{t}</span>)}
+          {post.tags.map(t => <span key={t} className="text-xs font-mono bg-primary/10 text-primary px-2 py-0.5 rounded">{t}</span>)}
         </div>
         <h1 className="text-3xl font-bold">{post.title}</h1>
       </header>
@@ -45,17 +36,11 @@ export default function Page({ params }: { params: { slug: string } }) {
 }
 
 export async function generateMetadata({ params }: { params: { slug: string } }) {
-  const post = getPost(params.slug);
+  const post = getPostBySlug(params.slug);
   if (!post) return { title: "Not Found" };
   return { title: post.title + " — Luis Gimenez", description: post.description };
 }
 
 export async function generateStaticParams() {
-  const slugs = [
-    "2026-06-01-inferencia-router-deep-dive",
-    "2026-06-04-watchdog-that-doesnt-bark",
-    "2026-06-07-rate-limit-postmortem",
-    "2026-06-10-file-based-rag-without-apology",
-  ];
-  return slugs.map(s => ({ slug: s }));
+  return getPostSlugs().map(slug => ({ slug }));
 }

--- a/src/app/writing/[slug]/page.tsx
+++ b/src/app/writing/[slug]/page.tsx
@@ -5,6 +5,9 @@ import { notFound } from "next/navigation";
 import type { Components } from "react-markdown";
 import { getPostBySlug, getPostSlugs } from "@/lib/posts-data";
 
+export const dynamic = "force-static";
+export const dynamicParams = false;
+
 const markdownComponents: Partial<Components> = {
   code({ className, children, ...props }) {
     return className

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -1,20 +1,9 @@
-import fs from "fs";
-import path from "path";
-import matter from "gray-matter";
 import Link from "next/link";
 import { Calendar } from "lucide-react";
+import { getAllPosts } from "@/lib/posts-data";
 
-function getPosts() {
-  const dir = path.join(process.cwd(), "src/content/posts");
-  if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir).filter(f => f.endsWith(".md")).map(f => {
-    const { data } = matter(fs.readFileSync(path.join(dir, f), "utf-8"));
-    return { slug: f.replace(/\.md$/, ""), title: data.title || "Untitled", description: data.description || "", date: data.date || "", tags: (data.tags || []) as string[] };
-  }).sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-}
-
-export default function Page() {
-  const posts = getPosts();
+export default function WritingPage() {
+  const posts = getAllPosts();
   return (
     <div className="mx-auto max-w-3xl px-4 pt-32 pb-24">
       <h1 className="text-4xl font-bold mb-2">Writing</h1>
@@ -25,7 +14,7 @@ export default function Page() {
             <Link href={"/writing/" + post.slug} className="block border border-border/40 rounded-xl p-6 hover:border-primary/40 transition-all">
               <div className="flex items-center gap-4 text-sm text-muted-foreground mb-3">
                 <span className="flex items-center gap-1.5"><Calendar className="size-3.5" />{new Date(post.date).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}</span>
-                {(post.tags as string[]).map(t => <span key={t} className="text-xs font-mono bg-primary/10 text-primary px-2 py-0.5 rounded">{t}</span>)}
+                {post.tags.map(t => <span key={t} className="text-xs font-mono bg-primary/10 text-primary px-2 py-0.5 rounded">{t}</span>)}
               </div>
               <h2 className="text-xl font-semibold group-hover:text-primary transition-colors mb-2">{post.title}</h2>
               <p className="text-muted-foreground">{post.description}</p>

--- a/src/lib/posts-data.ts
+++ b/src/lib/posts-data.ts
@@ -1,0 +1,47 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+
+export interface PostData {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  tags: string[];
+  content: string;
+}
+
+const POSTS_DIR = path.join(process.cwd(), "src/content/posts");
+
+let cachedPosts: PostData[] | null = null;
+
+export function getAllPosts(): PostData[] {
+  if (cachedPosts) return cachedPosts;
+  if (!fs.existsSync(POSTS_DIR)) return [];
+  
+  cachedPosts = fs.readdirSync(POSTS_DIR)
+    .filter(f => f.endsWith(".md"))
+    .map(f => {
+      const raw = fs.readFileSync(path.join(POSTS_DIR, f), "utf-8");
+      const { data, content } = matter(raw);
+      return {
+        slug: f.replace(/\.md$/, ""),
+        title: data.title || "Untitled",
+        description: data.description || "",
+        date: data.date || "",
+        tags: (data.tags || []) as string[],
+        content,
+      };
+    })
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  
+  return cachedPosts;
+}
+
+export function getPostBySlug(slug: string): PostData | undefined {
+  return getAllPosts().find(p => p.slug === slug);
+}
+
+export function getPostSlugs(): string[] {
+  return getAllPosts().map(p => p.slug);
+}


### PR DESCRIPTION
## Problem

The writing pages return 404 on Vercel preview/production. Root cause:  pre-builds the pages, but the RSC page component re-runs  at runtime via . In Vercel's serverless runtime, the  directory is not available, causing  to return null → .

## Fix

Extract file reading into a shared module () that caches in module scope. Both the list and slug pages import from this module. The cache ensures that at build time the files are read once, and the cached data is available during serverless runtime without additional filesystem reads.

## Files changed

-  (new) — shared post data module with getAllPosts, getPostBySlug, getPostSlugs
-  — imports from posts-data instead of raw fs calls
-  — same, removes fs/gray-matter imports