### PR TITLE
ci: only deploy on main branch via ignoreCommand

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "github": {
+    "silent": true,
+    "autoJobCancelation": true
+  },
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then exit 1; else exit 0; fi",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
Adds ignoreCommand to vercel.json — Vercel skips deploys on non-main branches.