### PR TITLE
fix(chat): use gemma4:e4b as default inference model

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -34,7 +34,7 @@ import {
 export const maxDuration = 60;
 
 const DEFAULT_BASE_URL = process.env.INFERENCIA_BASE_URL || "";
-const DEFAULT_CHAT_MODEL = "mlx-community/gpt-oss-20b-MXFP4-Q8";
+const DEFAULT_CHAT_MODEL = "gemma4:e4b";
 
 const SECURITY_HEADERS = {
   "Content-Type": "application/json",


### PR DESCRIPTION
The default model `mlx-community/gpt-oss-20b-MXFP4-Q8` does not exist on inferencia (which serves Ollama models like `gemma4:e4b`, `gpt-oss:20b-cloud`, `qwen3.6:27b-coding-mxfp8`).

This causes the chat API to hang/timeout (20s+) because the model isn't found.

Fix: change default to `gemma4:e4b` which is confirmed available and working on inferencia's Ollama backend.

Also verifies `INFERENCIA_CHAT_MODEL` env var on Vercel will override this if set.