### PR TITLE
fix: trigger redeploy with corrected INFERENCIA_BASE_URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ terraform/.terraform.lock.hcl
 /src/App.css
 /src/index.js
 /src/index.css
+.env*


### PR DESCRIPTION
INFERENCIA_BASE_URL was empty on Vercel production, causing chat timeout. Fixed via Vercel CLI. This commit triggers a new deployment.