### PR TITLE
fix(chat): reduce RAG context and probe Inferencia health

### DIFF
--- a/scripts/hermes-chat-watchdog.sh
+++ b/scripts/hermes-chat-watchdog.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Hermes no-agent cron watchdog for gimenez.dev chat + Inferencia chain.
+# Usage (on Pi5): hermes cron create "every 5m" --no-agent --script hermes-chat-watchdog.sh --deliver telegram --name "portfolio-chat-watchdog"
+#
+# Exit 0 + empty stdout  = healthy (silent tick)
+# Exit 0 + stdout         = alert delivered verbatim
+# Non-zero exit           = Hermes delivers error alert
+
+set -euo pipefail
+
+SITE_URL="${SITE_URL:-https://gimenez.dev}"
+CHAT_TIMEOUT="${CHAT_TIMEOUT:-45}"
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-10}"
+
+fail() {
+  echo "portfolio-chat-watchdog: $*"
+  exit 0
+}
+
+health_json="$(curl -fsS --max-time "$HEALTH_TIMEOUT" "${SITE_URL}/api/health")" || fail "GET /api/health failed"
+
+infer_status="$(printf '%s' "$health_json" | python3 -c "import json,sys; print(json.load(sys.stdin)['checks']['inference_api']['status'])" 2>/dev/null || echo unknown)"
+if [ "$infer_status" != "up" ]; then
+  fail "/api/health inference_api=${infer_status} (expected up)"
+fi
+
+chat_tmp="$(mktemp)"
+trap 'rm -f "$chat_tmp"' EXIT
+
+http_code="$(curl -sS --max-time "$CHAT_TIMEOUT" -o "$chat_tmp" -w '%{http_code}' -X POST "${SITE_URL}/api/chat" \
+  -H 'Content-Type: application/json' \
+  -d '{"messages":[{"role":"user","content":"ping"}]}')" || fail "POST /api/chat connection failed"
+
+if [ "$http_code" != "200" ]; then
+  body="$(head -c 200 "$chat_tmp" | tr '\n' ' ')"
+  fail "POST /api/chat returned HTTP ${http_code}: ${body}"
+fi
+
+if [ ! -s "$chat_tmp" ]; then
+  fail "POST /api/chat returned HTTP 200 but empty body"
+fi
+
+# Healthy — silent tick (watchdog pattern)
+exit 0

--- a/src/__tests__/api-chat.test.ts
+++ b/src/__tests__/api-chat.test.ts
@@ -135,10 +135,10 @@ describe("/api/chat — Inferencia configuration", () => {
     );
   });
 
-  it("calls streamText with maxOutputTokens 1500", async () => {
+  it("calls streamText with maxOutputTokens 800 and inference abort signal", async () => {
     await POST(makeChatRequest(validBody));
     expect(mockStreamText).toHaveBeenCalledWith(
-      expect.objectContaining({ maxOutputTokens: 1500 })
+      expect.objectContaining({ maxOutputTokens: 800, abortSignal: expect.any(AbortSignal) })
     );
   });
 

--- a/src/__tests__/api-health.test.ts
+++ b/src/__tests__/api-health.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { GET } from "@/app/api/health/route";
 
+vi.mock("@/lib/inferencia-health", () => ({
+  probeInferenciaHealth: vi.fn().mockResolvedValue({ status: "up", latency_ms: 42 }),
+}));
+
 beforeEach(() => {
   vi.spyOn(console, "log").mockImplementation(() => {});
 });

--- a/src/__tests__/inferencia-health.test.ts
+++ b/src/__tests__/inferencia-health.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { probeInferenciaHealth, resetInferenciaHealthCache } from "@/lib/inferencia-health";
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  resetInferenciaHealthCache();
+  vi.stubEnv("INFERENCIA_API_KEY", "test-key");
+  vi.stubEnv("INFERENCIA_BASE_URL", "https://llm.example.com/v1");
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.unstubAllEnvs();
+  resetInferenciaHealthCache();
+});
+
+describe("probeInferenciaHealth", () => {
+  it("returns degraded when INFERENCIA_API_KEY is missing", async () => {
+    delete process.env.INFERENCIA_API_KEY;
+    const result = await probeInferenciaHealth();
+    expect(result.status).toBe("degraded");
+  });
+
+  it("returns up when Inferencia /health responds healthy", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "healthy" }),
+    } as Response);
+
+    const result = await probeInferenciaHealth();
+    expect(result.status).toBe("up");
+    expect(result.latency_ms).toBeDefined();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://llm.example.com/health",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it("returns down when Inferencia /health is unreachable", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("network error"));
+
+    const result = await probeInferenciaHealth();
+    expect(result.status).toBe("down");
+  });
+});

--- a/src/__tests__/rag.test.ts
+++ b/src/__tests__/rag.test.ts
@@ -101,14 +101,23 @@ describe("rag", () => {
   // Test retrieveContext in a separate describe that uses dynamic import
   // so we can control the Cloud SQL env vars before module loads
   describe("retrieveContext", () => {
-    it("returns KNOWLEDGE_BASE when Cloud SQL env vars are missing", async () => {
-      // Default: no CLOUD_SQL_CONNECTION_NAME set → fallback path
-      const { retrieveContext } = await import("@/lib/rag");
-      const result = await retrieveContext("test query");
-      // KNOWLEDGE_BASE is a large string, just check it's substantial
+    it("returns a focused file context when Cloud SQL env vars are missing", async () => {
+      const { retrieveContext, retrieveFileContext } = await import("@/lib/rag");
+      const full = retrieveFileContext("payments observability grafana", 5);
+      const result = await retrieveContext("payments observability grafana");
       expect(result.length).toBeGreaterThan(100);
-      // Should NOT have called fetch (no embedding needed for fallback)
-      // Actually fetch might not be called since pool is null
+      expect(result.length).toBeLessThan(35000);
+      expect(result).toBe(full);
+    });
+
+    it("returns a smaller greeting context for low-signal queries", async () => {
+      const { retrieveFileContext } = await import("@/lib/rag");
+      const greeting = retrieveFileContext("hi there", 3);
+      const broad = retrieveFileContext("payments observability grafana card broker", 3);
+      expect(greeting.length).toBeGreaterThan(100);
+      expect(greeting.length).toBeLessThan(broad.length);
+      expect(greeting).toMatch(/SECTION 1/i);
+      expect(greeting).toMatch(/SECTION 9/i);
     });
   });
 });

--- a/src/__tests__/rag.test.ts
+++ b/src/__tests__/rag.test.ts
@@ -112,12 +112,15 @@ describe("rag", () => {
 
     it("returns a smaller greeting context for low-signal queries", async () => {
       const { retrieveFileContext } = await import("@/lib/rag");
+      const { KNOWLEDGE_BASE } = await import("@/lib/knowledge");
       const greeting = retrieveFileContext("hi there", 3);
       const broad = retrieveFileContext("payments observability grafana card broker", 3);
-      expect(greeting.length).toBeGreaterThan(100);
+      expect(greeting.length).toBeGreaterThan(500);
+      expect(greeting.length).toBeLessThan(KNOWLEDGE_BASE.length);
       expect(greeting.length).toBeLessThan(broad.length);
       expect(greeting).toMatch(/SECTION 1/i);
       expect(greeting).toMatch(/SECTION 9/i);
+      expect(greeting).toMatch(/Who Is Luis Gimenez/i);
     });
   });
 });

--- a/src/__tests__/telemetry.test.ts
+++ b/src/__tests__/telemetry.test.ts
@@ -376,6 +376,14 @@ describe("telemetry", () => {
       expect(data.checks.inference_api.status).toBe("up");
     });
 
+    it("returns unhealthy when Inferencia probe reports down", () => {
+      vi.stubEnv("INFERENCIA_API_KEY", "test-key");
+      const data = getHealthData({ status: "down", latency_ms: 5000 });
+      expect(data.status).toBe("unhealthy");
+      expect(data.checks.inference_api.status).toBe("down");
+      expect(data.checks.inference_api.latency_ms).toBe(5000);
+    });
+
     it("includes budget_remaining in rate_limiter check", () => {
       const data = getHealthData();
       expect(data.checks.rate_limiter.budget_remaining).toBeDefined();

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -261,7 +261,7 @@ export async function POST(req: Request) {
 
     // RAG retrieval span (topK=8 for enterprise context)
     const ragStart = Date.now();
-    const context = await retrieveContext(sanitizedContent, 8);
+    const context = await retrieveContext(sanitizedContent, 5);
     const ragDurationMs = Date.now() - ragStart;
 
     const systemPrompt = `[SYSTEM BOUNDARY — IMMUTABLE INSTRUCTIONS]

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -33,6 +33,8 @@ import {
 
 export const maxDuration = 60;
 
+const INFERENCE_TIMEOUT_MS = 50_000;
+
 const DEFAULT_BASE_URL = process.env.INFERENCIA_BASE_URL || "";
 const DEFAULT_CHAT_MODEL = "gemma4:e4b";
 
@@ -301,15 +303,17 @@ ${context}`;
     const model = process.env.INFERENCIA_CHAT_MODEL || DEFAULT_CHAT_MODEL;
     const openai = createOpenAI({ baseURL, apiKey });
 
-    // Inference span
+    // Inference span — abort before Vercel's 60s limit so clients get 503 instead of 504
     const inferenceStart = Date.now();
+    const inferenceAbort = AbortSignal.timeout(INFERENCE_TIMEOUT_MS);
     const result = await streamText({
       model: openai.chat(model),
       system: systemPrompt,
       messages: messagesForModel,
       maxRetries: 1,
-      maxOutputTokens: 1500,
+      maxOutputTokens: 800,
       temperature: 0.5,
+      abortSignal: inferenceAbort,
     });
     incrementDailyCount();
 

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,3 +1,4 @@
+import { probeInferenciaHealth } from "@/lib/inferencia-health";
 import { getTraceIdFromRequest } from "@/lib/trace-context";
 import { getHealthData, log, recordRequest } from "@/lib/telemetry";
 
@@ -6,7 +7,8 @@ export const dynamic = "force-dynamic";
 export async function GET(req: Request) {
   const start = Date.now();
   const traceId = getTraceIdFromRequest(req);
-  const health = getHealthData();
+  const inferenciaProbe = await probeInferenciaHealth();
+  const health = getHealthData(inferenciaProbe);
 
   log("INFO", "Health check", {
     endpoint: "/api/health",

--- a/src/app/api/war-room/explain-error/route.ts
+++ b/src/app/api/war-room/explain-error/route.ts
@@ -10,7 +10,7 @@ import { recordRequest } from "@/lib/telemetry";
 export const maxDuration = 30;
 
 const DEFAULT_BASE_URL = process.env.INFERENCIA_BASE_URL || "";
-const DEFAULT_CHAT_MODEL = process.env.INFERENCIA_CHAT_MODEL || "mlx-community/gpt-oss-20b-MXFP4-Q8";
+const DEFAULT_CHAT_MODEL = "gemma4:e4b";
 
 const SYSTEM_PROMPT = `You are a DevOps/SRE assistant. The user will paste an error message or log line from their application.
 Your job: explain what the error means in plain language and suggest 1–3 concrete fixes. Be concise (under 150 words).

--- a/src/lib/inferencia-health.ts
+++ b/src/lib/inferencia-health.ts
@@ -1,0 +1,62 @@
+/**
+ * Lightweight Inferencia connectivity probe for /api/health.
+ * Caches results briefly to avoid hammering the inference gateway on uptime checks.
+ */
+
+const CACHE_TTL_MS = 30_000;
+
+let cached:
+  | { status: "up" | "down" | "degraded"; latency_ms?: number; checked_at: number }
+  | null = null;
+
+function inferenciaHealthUrl(): string | null {
+  const baseURL = process.env.INFERENCIA_BASE_URL?.trim();
+  if (!baseURL) return null;
+  const origin = baseURL.replace(/\/v1\/?$/, "");
+  return `${origin}/health`;
+}
+
+export async function probeInferenciaHealth(): Promise<{
+  status: "up" | "down" | "degraded";
+  latency_ms?: number;
+}> {
+  if (cached && Date.now() - cached.checked_at < CACHE_TTL_MS) {
+    return { status: cached.status, latency_ms: cached.latency_ms };
+  }
+
+  const apiKey = process.env.INFERENCIA_API_KEY;
+  const healthUrl = inferenciaHealthUrl();
+
+  if (!apiKey) {
+    const result = { status: "degraded" as const };
+    cached = { ...result, checked_at: Date.now() };
+    return result;
+  }
+
+  if (!healthUrl) {
+    const result = { status: "degraded" as const };
+    cached = { ...result, checked_at: Date.now() };
+    return result;
+  }
+
+  const start = Date.now();
+  try {
+    const res = await fetch(healthUrl, { signal: AbortSignal.timeout(5000) });
+    const latency_ms = Date.now() - start;
+    const body = (await res.json().catch(() => null)) as { status?: string } | null;
+    const backendHealthy = res.ok && body?.status === "healthy";
+    const result = { status: backendHealthy ? ("up" as const) : ("down" as const), latency_ms };
+    cached = { ...result, checked_at: Date.now() };
+    return result;
+  } catch {
+    const latency_ms = Date.now() - start;
+    const result = { status: "down" as const, latency_ms };
+    cached = { ...result, checked_at: Date.now() };
+    return result;
+  }
+}
+
+/** Reset cache between tests. */
+export function resetInferenciaHealthCache(): void {
+  cached = null;
+}

--- a/src/lib/rag.ts
+++ b/src/lib/rag.ts
@@ -68,6 +68,74 @@ export async function generateEmbedding(text: string): Promise<number[]> {
 
 import { KNOWLEDGE_BASE } from "./knowledge";
 
+const FILE_SECTION_SPLIT = /(?=# ═{3,})/;
+const GREETING_TOKENS = new Set(["hi", "hello", "hey", "there", "thanks", "thank", "yo", "howdy"]);
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, " ")
+      .split(/\s+/)
+      .filter((word) => word.length > 2)
+  );
+}
+
+function scoreSection(section: string, queryTokens: Set<string>): number {
+  const sectionTokens = tokenize(section);
+  let score = 0;
+  for (const token of queryTokens) {
+    if (sectionTokens.has(token)) score++;
+  }
+  return score;
+}
+
+function isLowSignalQuery(query: string, queryTokens: Set<string>): boolean {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed || trimmed.length <= 12) return true;
+  if (queryTokens.size <= 2 && [...queryTokens].every((token) => GREETING_TOKENS.has(token))) {
+    return true;
+  }
+  return false;
+}
+
+/** File-based retrieval: return the most relevant KB sections instead of the full document. */
+export function retrieveFileContext(query: string, topK = 3): string {
+  const sections = KNOWLEDGE_BASE.split(FILE_SECTION_SPLIT).filter((section) => section.trim().length > 50);
+  if (sections.length === 0) return KNOWLEDGE_BASE;
+
+  const queryTokens = tokenize(query);
+  const behaviorIdx = sections.findIndex((section) => /SECTION 9/i.test(section));
+  const identityIdx = sections.findIndex((section) => /SECTION 1/i.test(section));
+  const selected = new Set<number>();
+
+  if (behaviorIdx >= 0) selected.add(behaviorIdx);
+
+  if (isLowSignalQuery(query, queryTokens)) {
+    if (identityIdx >= 0) selected.add(identityIdx);
+  } else {
+    const ranked = sections
+      .map((section, idx) => ({ idx, score: scoreSection(section, queryTokens) }))
+      .filter(({ idx }) => idx !== behaviorIdx)
+      .sort((a, b) => b.score - a.score);
+
+    for (const { idx, score } of ranked) {
+      if (selected.size >= topK + (behaviorIdx >= 0 ? 1 : 0)) break;
+      if (score > 0 || selected.size < 2) selected.add(idx);
+    }
+
+    if (selected.size <= 1 && identityIdx >= 0) selected.add(identityIdx);
+    if (selected.size <= 1) {
+      for (const { idx } of ranked.slice(0, 2)) selected.add(idx);
+    }
+  }
+
+  return [...selected]
+    .sort((a, b) => a - b)
+    .map((idx) => sections[idx].trim())
+    .join("\n\n");
+}
+
 function deduplicateContext(context: string): string {
   const chunkSeparator = "\n\n---\n\n";
   const chunks = context
@@ -95,7 +163,7 @@ export async function retrieveContext(query: string, topK = 5): Promise<string> 
   const client = getPool();
 
   if (!client) {
-    return KNOWLEDGE_BASE;
+    return retrieveFileContext(query, topK);
   }
 
   try {
@@ -108,7 +176,7 @@ export async function retrieveContext(query: string, topK = 5): Promise<string> 
     );
 
     if (!rows || rows.length === 0) {
-      return KNOWLEDGE_BASE;
+      return retrieveFileContext(query, topK);
     }
 
     const raw = rows
@@ -116,6 +184,6 @@ export async function retrieveContext(query: string, topK = 5): Promise<string> 
       .join("\n\n---\n\n");
     return deduplicateContext(raw);
   } catch {
-    return KNOWLEDGE_BASE;
+    return retrieveFileContext(query, topK);
   }
 }

--- a/src/lib/rag.ts
+++ b/src/lib/rag.ts
@@ -68,7 +68,8 @@ export async function generateEmbedding(text: string): Promise<number[]> {
 
 import { KNOWLEDGE_BASE } from "./knowledge";
 
-const FILE_SECTION_SPLIT = /(?=# ═{3,})/;
+const FILE_SECTION_SPLIT = /(?=# ═{3,}\n# SECTION \d+:)/;
+const FILE_PREAMBLE_MAX_CHARS = 2500;
 const GREETING_TOKENS = new Set(["hi", "hello", "hey", "there", "thanks", "thank", "yo", "howdy"]);
 
 function tokenize(text: string): Set<string> {
@@ -99,14 +100,19 @@ function isLowSignalQuery(query: string, queryTokens: Set<string>): boolean {
   return false;
 }
 
+function splitKnowledgeSections(): string[] {
+  const parts = KNOWLEDGE_BASE.split(FILE_SECTION_SPLIT).map((section) => section.trim());
+  return parts.filter((section) => section.length > 50);
+}
+
 /** File-based retrieval: return the most relevant KB sections instead of the full document. */
 export function retrieveFileContext(query: string, topK = 3): string {
-  const sections = KNOWLEDGE_BASE.split(FILE_SECTION_SPLIT).filter((section) => section.trim().length > 50);
+  const sections = splitKnowledgeSections();
   if (sections.length === 0) return KNOWLEDGE_BASE;
 
   const queryTokens = tokenize(query);
-  const behaviorIdx = sections.findIndex((section) => /SECTION 9/i.test(section));
-  const identityIdx = sections.findIndex((section) => /SECTION 1/i.test(section));
+  const behaviorIdx = sections.findIndex((section) => /SECTION 9:/i.test(section));
+  const identityIdx = sections.findIndex((section) => /SECTION 1:/i.test(section));
   const selected = new Set<number>();
 
   if (behaviorIdx >= 0) selected.add(behaviorIdx);
@@ -130,10 +136,18 @@ export function retrieveFileContext(query: string, topK = 3): string {
     }
   }
 
-  return [...selected]
+  const body = [...selected]
     .sort((a, b) => a - b)
     .map((idx) => sections[idx].trim())
     .join("\n\n");
+
+  if (!isLowSignalQuery(query, queryTokens)) return body;
+
+  const preamble = KNOWLEDGE_BASE.split(FILE_SECTION_SPLIT)[0]?.trim() ?? "";
+  if (preamble.length <= FILE_PREAMBLE_MAX_CHARS) {
+    return `${preamble}\n\n${body}`.trim();
+  }
+  return body;
 }
 
 function deduplicateContext(context: string): string {

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -421,16 +421,29 @@ export interface HealthData {
   region: string;
 }
 
-export function getHealthData(): HealthData {
+export function getHealthData(inferenciaProbe?: {
+  status: "up" | "down" | "degraded";
+  latency_ms?: number;
+}): HealthData {
   const hasInferenceKey = !!process.env.INFERENCIA_API_KEY;
   const budgetUsed = getCounter("chat_conversations_total");
   const budgetMax = parseInt(process.env.CHAT_DAILY_BUDGET || "150");
   const budgetRemaining = Math.max(0, budgetMax - budgetUsed);
 
+  const inferenceStatus = !hasInferenceKey
+    ? "degraded"
+    : inferenciaProbe?.status === "down"
+      ? "down"
+      : inferenciaProbe?.status === "degraded"
+        ? "degraded"
+        : "up";
+
   const checks: HealthData["checks"] = {
     inference_api: {
-      status: hasInferenceKey ? "up" : "degraded",
-      latency_ms: Math.round(percentile("chat_inference_duration_seconds", 50, 300000)) || undefined,
+      status: inferenceStatus,
+      latency_ms:
+        inferenciaProbe?.latency_ms ??
+        (Math.round(percentile("chat_inference_duration_seconds", 50, 300000)) || undefined),
     },
     rag_system: {
       status: "up",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Chat was intermittently showing **"Server temporarily unavailable"** because `/api/chat` hit Vercel's 60s function timeout.

Investigation showed:
- **Inferencia is healthy** — `https://llm.menezmethod.com/health` reports all backends up, including `gemma4:e4b` on Ollama
- **Inference is slow** — simple greetings took ~48–60s end-to-end
- **Root cause** — file-based RAG was sending the entire **34KB** `KNOWLEDGE_BASE` on every request (no Cloud SQL on Vercel), bloating the prompt
- **Health check was misleading** — `/api/health` reported `inference_api: up` when only `INFERENCIA_API_KEY` was set, without probing Inferencia

## Changes

1. **Section-based file RAG** (`retrieveFileContext`) — returns relevant KB sections instead of the full document; greetings get Section 1 + Section 9 only
2. **Real Inferencia probe** — `/api/health` now calls Inferencia `/health` (5s timeout, 30s cache)
3. **Model alignment** — `explain-error` default model updated to `gemma4:e4b` (matches chat route)
4. **Reduced topK** — chat retrieval from 8 → 5 chunks

## Verification

- `npm run test` — 197 tests pass
- `npm run lint` — 0 errors
- `npm run build` — succeeds

## Follow-up (manual)

After merge, verify on production:
```bash
curl -s https://gimenez.dev/api/health | jq .checks.inference_api
curl -s -m 30 -X POST https://gimenez.dev/api/chat \
  -H 'Content-Type: application/json' \
  -d '{"messages":[{"role":"user","content":"hi there"}]}'
```
Expected: health shows Inferencia latency; chat responds in under 30s.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eace6395-f15d-4ad2-be14-8eed503f29c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eace6395-f15d-4ad2-be14-8eed503f29c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

