### PR TITLE
fix(deploy): main-only Vercel builds — stop preview quota burn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   terraform:
     runs-on: ubuntu-latest
@@ -79,26 +83,3 @@ jobs:
           start: npm run start
           wait-on: "http://localhost:3000"
           wait-on-timeout: 120
-
-  deploy-vercel:
-    runs-on: ubuntu-latest
-    needs: cypress
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Deploy to Vercel production (optional)
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-        run: |
-          if [ -z "$VERCEL_TOKEN" ] || [ -z "$VERCEL_ORG_ID" ] || [ -z "$VERCEL_PROJECT_ID" ]; then
-            echo "::warning::Vercel deploy skipped — add VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID to GitHub secrets."
-            echo "Vercel Git integration still deploys on main when lgportfolio is the only connected project."
-            exit 0
-          fi
-          npm install -g vercel@latest
-          vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
-          vercel build --prod --token="$VERCEL_TOKEN"
-          vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/docs/VERCEL-CLEANUP.md
+++ b/docs/VERCEL-CLEANUP.md
@@ -1,64 +1,50 @@
-# Vercel project cleanup
+# Vercel cleanup — one project, main-only deploys
 
-## Problem
+## Canonical setup
 
-Three Vercel projects are connected to this repo. Every push/PR triggers **three builds**:
+| Item | Value |
+|------|--------|
+| Vercel team | `menezmethods-projects` |
+| Project | **`lgportfolio` only** (domains: `gimenez.dev`, `www.gimenez.dev`) |
+| GitHub repo | `menezmethod/lgportfolio` |
+| Production deploy | **Merge to `main` only** (Vercel Git integration) |
+| PR previews | **Disabled** (`scripts/vercel-should-build.sh` skips `VERCEL_ENV=preview`) |
+| CI | GitHub Actions (`ci.yml`) — lint, build, test, Cypress on PRs and main |
 
-| Project | Status |
-|---------|--------|
-| `lgportfolio` | **Keep** — serves `gimenez.dev` |
-| `lgportfolio-inline` | **Disconnect** — duplicate, burns build minutes |
-| `lgportfolio-fix` | **Disconnect** — duplicate, burns build minutes |
+## Removed duplicates (2026-06-10)
 
-## Target behavior
+Do not recreate these projects — they tripled deployment quota:
 
-| Event | What deploys |
-|-------|----------------|
-| Open/update PR | **Preview** on `lgportfolio` only |
-| Merge to `main` | **Production** on `lgportfolio` only |
-| Any event | `lgportfolio-inline` / `lgportfolio-fix` → **skipped** |
+- `lgportfolio-fix` (deleted)
+- `lgportfolio-inline` (deleted)
 
-Controlled by `scripts/vercel-should-build.sh` in `vercel.json`.
+## Hermes / agent rules
 
-## One-time setup (Vercel Dashboard)
+- **Never** `vercel link` a second project for this repo
+- **Never** `vercel --prod` or `vercel rollback` from crons (report-only watchdogs)
+- Portfolio weekly audit → PR to `main`; humans merge; Vercel deploys once
 
-### Step 1 — Disconnect duplicate projects
+## Watchdogs (no chat POST spam)
 
-For **`lgportfolio-inline`** and **`lgportfolio-fix`**:
+- `scripts/hermes-chat-watchdog.sh` — uses `/api/health` only (no POST `/api/chat`)
+- `~/.hermes/scripts/inferencia-watchdog.py` — same pattern
 
-1. [Vercel Dashboard](https://vercel.com/dashboard) → open project
-2. **Settings** → **Git** → **Disconnect**
-3. (Optional) Delete the project entirely if unused
-
-### Step 2 — Configure canonical project
-
-On **`lgportfolio`** only:
-
-1. **Settings** → **Environment Variables** → add:
-
-| Name | Value | Environments |
-|------|-------|--------------|
-| `VERCEL_CANONICAL_PROJECT` | `1` | Production, Preview, Development |
-
-2. **Settings** → **Git** → enable **Automatically expose System Environment Variables**
-
-3. Confirm **Production Branch** = `main`
-
-### Step 3 — Verify after next PR
-
-GitHub checks should show:
-
-- `Vercel – lgportfolio` — building or success
-- `Vercel – lgportfolio-inline` — **Canceled / Ignored** (or gone after disconnect)
-- `Vercel – lgportfolio-fix` — **Canceled / Ignored** (or gone after disconnect)
-
-After merge to `main`, only one production deploy:
+## Manual commands
 
 ```bash
-gh api 'repos/menezmethod/lgportfolio/deployments?per_page=5' \
-  --jq '.[] | select(.environment | test("lgportfolio")) | {environment, sha: .sha[0:7], created_at}'
+# Inventory + deploy budget
+python3 ~/.hermes/scripts/vercel-governor.py --report
+
+# Production deploy (Tier 3 — human only)
+cd /Users/luisgimenez/Development/03-products/lgportfolio
+git checkout main && git pull
+# merge PR in GitHub → Vercel builds automatically
 ```
 
-## Optional: CI deploy backup
+## Troubleshooting
 
-Add GitHub secrets for `lgportfolio` project ID only. See `docs/VERCEL-DEPLOY.md` §6.
+**Queued builds piling up:** Dashboard → lgportfolio → Cancel queued. Fix branch churn; previews are off.
+
+**Main not deploying:** Confirm `vercel.json` `ignoreCommand` points at `scripts/vercel-should-build.sh` and latest commit is on `main`.
+
+**Stale production SHA:** Site may still be HTTP 200 — run governor report; merge pending work or promote manually (human decision).

--- a/docs/VERCEL-DEPLOY.md
+++ b/docs/VERCEL-DEPLOY.md
@@ -2,6 +2,8 @@
 
 GCP assets (`terraform/`, `cloudbuild.yaml`, `Dockerfile`) stay in the repo for rollback; production traffic is intended to run on **Vercel** after you point DNS here.
 
+**Deploy policy (2026-06):** One Vercel project (`lgportfolio`). Production builds **only on merge to `main`**. PR previews are disabled to protect deployment quota — see [VERCEL-CLEANUP.md](./VERCEL-CLEANUP.md).
+
 ## 1. Create the project
 
 1. [Vercel Dashboard](https://vercel.com/dashboard) → **Add New…** → **Project** → import `menezmethod/lgportfolio`.

--- a/scripts/hermes-chat-watchdog.sh
+++ b/scripts/hermes-chat-watchdog.sh
@@ -1,15 +1,13 @@
 #!/usr/bin/env bash
-# Hermes no-agent cron watchdog for gimenez.dev chat + Inferencia chain.
-# Usage (on Pi5): hermes cron create "every 5m" --no-agent --script hermes-chat-watchdog.sh --deliver telegram --name "portfolio-chat-watchdog"
+# Hermes no-agent cron watchdog for gimenez.dev + Inferencia chain.
+# Uses /api/health only — never POST /api/chat (avoids LLM spend + rate limits).
 #
-# Exit 0 + empty stdout  = healthy (silent tick)
-# Exit 0 + stdout         = alert delivered verbatim
-# Non-zero exit           = Hermes delivers error alert
+# Exit 0 + empty stdout = healthy (silent)
+# Exit 0 + stdout         = alert delivered
 
 set -euo pipefail
 
 SITE_URL="${SITE_URL:-https://gimenez.dev}"
-CHAT_TIMEOUT="${CHAT_TIMEOUT:-45}"
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-10}"
 
 fail() {
@@ -24,21 +22,10 @@ if [ "$infer_status" != "up" ]; then
   fail "/api/health inference_api=${infer_status} (expected up)"
 fi
 
-chat_tmp="$(mktemp)"
-trap 'rm -f "$chat_tmp"' EXIT
-
-http_code="$(curl -sS --max-time "$CHAT_TIMEOUT" -o "$chat_tmp" -w '%{http_code}' -X POST "${SITE_URL}/api/chat" \
-  -H 'Content-Type: application/json' \
-  -d '{"messages":[{"role":"user","content":"ping"}]}')" || fail "POST /api/chat connection failed"
-
-if [ "$http_code" != "200" ]; then
-  body="$(head -c 200 "$chat_tmp" | tr '\n' ' ')"
-  fail "POST /api/chat returned HTTP ${http_code}: ${body}"
+# Chat route alive (HEAD — no inference call)
+chat_code="$(curl -sS --max-time "$HEALTH_TIMEOUT" -o /dev/null -w '%{http_code}' -X HEAD "${SITE_URL}/api/chat" || echo 000)"
+if [ "$chat_code" != "405" ] && [ "$chat_code" != "200" ]; then
+  fail "HEAD /api/chat returned HTTP ${chat_code} (expected 405 or 200)"
 fi
 
-if [ ! -s "$chat_tmp" ]; then
-  fail "POST /api/chat returned HTTP 200 but empty body"
-fi
-
-# Healthy — silent tick (watchdog pattern)
 exit 0

--- a/scripts/vercel-should-build.sh
+++ b/scripts/vercel-should-build.sh
@@ -1,41 +1,17 @@
 #!/usr/bin/env bash
-# Vercel Ignored Build Step
+# Vercel Ignored Build Step — main-only production deploys.
 #
-# One canonical project (lgportfolio) builds:
-#   - Preview on PRs / non-main branches
-#   - Production when merged to main
+# PR / branch pushes: skip (GitHub Actions CI validates PRs; no Vercel preview builds).
+# Production: build only when Git merges to main.
 #
-# Duplicate projects (lgportfolio-inline, lgportfolio-fix) always skip.
-#
-# Setup on lgportfolio only (Vercel → Settings → Environment Variables):
-#   VERCEL_CANONICAL_PROJECT=1   (all environments, or at least Preview + Production)
-#
-# Also: disconnect Git on lgportfolio-inline and lgportfolio-fix (see docs/VERCEL-CLEANUP.md)
-#
-# Exit 0 = skip | Exit 1 = build
+# Exit 0 = skip build | Exit 1 = proceed with build
 
 set -euo pipefail
 
-if [ "${VERCEL_CANONICAL_PROJECT:-}" != "1" ]; then
-  echo "skip: duplicate Vercel project (not lgportfolio)"
-  exit 0
+if [ "${VERCEL_ENV:-}" = "production" ] && [ "${VERCEL_GIT_COMMIT_REF:-}" = "main" ]; then
+  echo "build: production deploy from main"
+  exit 1
 fi
 
-case "${VERCEL_ENV:-}" in
-  preview)
-    echo "build: canonical preview"
-    exit 1
-    ;;
-  production)
-    if [ "${VERCEL_GIT_COMMIT_REF:-}" = "main" ]; then
-      echo "build: canonical production (main)"
-      exit 1
-    fi
-    echo "skip: production deploy only allowed from main"
-    exit 0
-    ;;
-  *)
-    echo "skip: unknown VERCEL_ENV=${VERCEL_ENV:-unset}"
-    exit 0
-    ;;
-esac
+echo "skip: env=${VERCEL_ENV:-unset} ref=${VERCEL_GIT_COMMIT_REF:-unset}"
+exit 0

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "github": {
-    "silent": true
+    "silent": true,
+    "autoJobCancelation": true
   },
   "ignoreCommand": "bash scripts/vercel-should-build.sh",
   "framework": "nextjs"


### PR DESCRIPTION
## Summary
- Disable Vercel preview builds (PR validation stays in GitHub Actions CI only)
- Simplify `vercel-should-build.sh` — production builds only on `main`, no extra env vars
- Remove dead optional `deploy-vercel` GitHub Actions job (avoid double-deploy path)
- Add CI concurrency cancel-in-progress
- Watchdog: `/api/health` + HEAD `/api/chat` (no POST /api/chat spend)
- Document cleanup in `docs/VERCEL-CLEANUP.md`

## Context
Hermes/agent PR loops + duplicate Vercel projects burned ~63 deploys/24h. Duplicate projects removed; this stops preview churn on open Cursor branches.

## Test plan
- [x] `vercel-should-build.sh` — preview skips (exit 0), main production builds (exit 1)
- [ ] CI green on this PR (no Vercel preview expected)
- [ ] After merge: one production deploy on main

Made with [Cursor](https://cursor.com)