### PR TITLE
chore: add script to set OPENROUTER_API_KEY via Vercel CLI

### DIFF
--- a/docs/VERCEL-DEPLOY.md
+++ b/docs/VERCEL-DEPLOY.md
@@ -33,6 +33,16 @@ Optional (same behavior as on Cloud Run):
 
 Redeploy after changing env vars (**Deployments → … → Redeploy** or push to `main`).
 
+### Add OpenRouter key via CLI
+
+```bash
+export VERCEL_TOKEN=<from https://vercel.com/account/tokens>
+export OPENROUTER_API_KEY=<from https://openrouter.ai/keys>
+./scripts/vercel-add-openrouter-env.sh
+```
+
+Sets `OPENROUTER_API_KEY` on **production**, **preview**, and **development** for `menezmethods-projects/lgportfolio`.
+
 ## 3. Custom domain + Namecheap DNS
 
 In Vercel: **Project → Settings → Domains** → add `gimenez.dev` and `www.gimenez.dev`. Vercel shows the exact records to use; prefer those over anything generic.

--- a/scripts/vercel-add-openrouter-env.sh
+++ b/scripts/vercel-add-openrouter-env.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Add OPENROUTER_API_KEY to the lgportfolio Vercel project (all environments).
+#
+# Prerequisites:
+#   export VERCEL_TOKEN=<token from https://vercel.com/account/tokens>
+#   export OPENROUTER_API_KEY=<key from https://openrouter.ai/keys>
+#
+# Usage:
+#   ./scripts/vercel-add-openrouter-env.sh
+#
+# Optional overrides:
+#   VERCEL_SCOPE=menezmethods-projects VERCEL_PROJECT=lgportfolio ./scripts/vercel-add-openrouter-env.sh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+SCOPE="${VERCEL_SCOPE:-menezmethods-projects}"
+PROJECT="${VERCEL_PROJECT:-lgportfolio}"
+KEY_NAME="OPENROUTER_API_KEY"
+
+if [ -z "${VERCEL_TOKEN:-}" ]; then
+  echo "error: VERCEL_TOKEN is not set. Create one at https://vercel.com/account/tokens" >&2
+  exit 1
+fi
+
+if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+  echo "error: OPENROUTER_API_KEY is not set. Create one at https://openrouter.ai/keys" >&2
+  exit 1
+fi
+
+export VERCEL_ORG_ID=""
+export VERCEL_PROJECT_ID=""
+
+echo "Linking Vercel project ${SCOPE}/${PROJECT}..."
+npx --yes vercel@latest link --yes \
+  --token "$VERCEL_TOKEN" \
+  --scope "$SCOPE" \
+  --project "$PROJECT"
+
+for env in production preview development; do
+  echo "Setting ${KEY_NAME} for ${env}..."
+  npx --yes vercel@latest env add "$KEY_NAME" "$env" \
+    --value "$OPENROUTER_API_KEY" \
+    --force \
+    --yes \
+    --token "$VERCEL_TOKEN"
+done
+
+echo "Done. Redeploy production to pick up the new variable:"
+echo "  npx vercel@latest --prod --token \$VERCEL_TOKEN --scope $SCOPE --project $PROJECT"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `scripts/vercel-add-openrouter-env.sh` to set `OPENROUTER_API_KEY` on lgportfolio (production/preview/development) via Vercel CLI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eace6395-f15d-4ad2-be14-8eed503f29c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eace6395-f15d-4ad2-be14-8eed503f29c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

