### PR TITLE
chore: clean up stale git branches and tighten Vercel deploy config

### DIFF
--- a/docs/VERCEL-CLEANUP.md
+++ b/docs/VERCEL-CLEANUP.md
@@ -18,6 +18,20 @@ Do not recreate these projects — they tripled deployment quota:
 - `lgportfolio-fix` (deleted)
 - `lgportfolio-inline` (deleted)
 
+## Git branch cleanup (2026-06-10)
+
+Stale remote branches (agent `cursor/*`, duplicate `master`, deploy trigger branches) were removed so pushes do not leave clutter in GitHub.
+
+```bash
+# Preview, then apply
+./scripts/git-cleanup-stale-branches.sh
+./scripts/git-cleanup-stale-branches.sh --apply
+```
+
+**Recommended (one-time, in GitHub UI):** Repo → **Settings → General** → enable **Automatically delete head branches** after PR merge.
+
+Old **Deployments** rows (`Production – lgportfolio-inline`, etc.) stay in GitHub history — harmless; new merges only report `Production`.
+
 ## Hermes / agent rules
 
 - **Never** `vercel link` a second project for this repo

--- a/docs/VERCEL-DEPLOY.md
+++ b/docs/VERCEL-DEPLOY.md
@@ -87,17 +87,16 @@ After CI passes on `main`, GitHub Actions can deploy to the **`lgportfolio`** Ve
 
 Until secrets are set, CI prints a warning and you must redeploy manually.
 
-## 7. One Vercel project (required cleanup)
+## 7. One Vercel project (cleanup done)
 
-Three Vercel projects are hooked to this repo — every push fires **three builds**. See **`docs/VERCEL-CLEANUP.md`**.
+Duplicate Vercel projects (`lgportfolio-inline`, `lgportfolio-fix`) were **deleted**. Only **`lgportfolio`** should be connected to this repo. See **`docs/VERCEL-CLEANUP.md`**.
 
 Deploy model:
 
-- **PR** → preview on `lgportfolio` only
-- **Merge to `main`** → production on `lgportfolio` only
-- **`lgportfolio-inline` / `lgportfolio-fix`** → disconnect Git (or builds are skipped via `scripts/vercel-should-build.sh`)
+- **PR** → no Vercel build (`scripts/vercel-should-build.sh` skips preview)
+- **Merge to `main`** → one production deploy on `lgportfolio`
 
-Set `VERCEL_CANONICAL_PROJECT=1` on **lgportfolio** (all envs). Enable **Automatically expose System Environment Variables**.
+Enable **Automatically expose System Environment Variables** on the Vercel project.
 
 ## 8. Troubleshooting: “pushes to main don’t deploy”
 
@@ -106,9 +105,9 @@ Set `VERCEL_CANONICAL_PROJECT=1` on **lgportfolio** (all envs). Enable **Automat
 **Check:**
 
 ```bash
-# Last production deploy for lgportfolio (not inline/fix)
+# Last production deploy (post-cleanup: environment is "Production")
 gh api 'repos/menezmethod/lgportfolio/deployments?per_page=5' \
-  --jq '.[] | select(.environment=="Production – lgportfolio") | {created_at, sha: .sha[0:7]}'
+  --jq '.[] | select(.environment=="Production") | {created_at, sha: .sha[0:7]}'
 ```
 
 **Verify new code is live** (after chat fix merge):
@@ -123,7 +122,7 @@ curl -s https://gimenez.dev/api/health | jq .checks.inference_api
 | Cause | Fix |
 |-------|-----|
 | Wrong Vercel project updated | Redeploy **lgportfolio** (not inline/fix) |
-| `autoJobCancelation` canceled in-flight builds | Removed from `vercel.json`; rapid merges no longer cancel production |
+| `autoJobCancelation` canceled in-flight builds | Disabled in `vercel.json`; rapid merges no longer cancel production |
 | Git integration flaky | Use CI deploy secrets (section 6) |
 | Env vars changed | Redeploy after updating Vercel env vars |
 

--- a/scripts/git-cleanup-stale-branches.sh
+++ b/scripts/git-cleanup-stale-branches.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Delete remote branches that are fully merged into main, plus known stale agent/deploy branches.
+#
+# Usage:
+#   ./scripts/git-cleanup-stale-branches.sh          # dry-run (default)
+#   ./scripts/git-cleanup-stale-branches.sh --apply  # delete on GitHub
+#
+# Requires: gh CLI authenticated for menezmethod/lgportfolio
+
+set -euo pipefail
+
+REPO="${GITHUB_REPO:-menezmethod/lgportfolio}"
+BASE="${BASE_BRANCH:-main}"
+APPLY=false
+
+if [[ "${1:-}" == "--apply" ]]; then
+  APPLY=true
+fi
+
+git fetch origin --prune
+
+# Branches always safe to remove (deploy churn, duplicate default, agent scratch)
+ALWAYS_DELETE=(
+  master
+  chore/trigger-deploy
+  fix/env-redeploy
+)
+
+mapfile -t MERGED < <(git branch -r --merged "origin/$BASE" | sed 's/^[* ]*origin\///' | rg -v "^(HEAD -> $BASE|$BASE)$" || true)
+
+mapfile -t CURSOR < <(gh api "repos/$REPO/branches?per_page=100" --jq '.[].name' | rg '^cursor/' || true)
+
+declare -A SEEN=()
+TO_DELETE=()
+
+add_branch() {
+  local b="$1"
+  [[ -z "$b" || "$b" == "$BASE" ]] && return
+  [[ -n "${SEEN[$b]:-}" ]] && return
+  SEEN[$b]=1
+  TO_DELETE+=("$b")
+}
+
+for b in "${ALWAYS_DELETE[@]}"; do add_branch "$b"; done
+for b in "${MERGED[@]}"; do add_branch "$b"; done
+for b in "${CURSOR[@]}"; do add_branch "$b"; done
+
+if [[ ${#TO_DELETE[@]} -eq 0 ]]; then
+  echo "Nothing to delete."
+  exit 0
+fi
+
+echo "Branches targeted (${#TO_DELETE[@]}):"
+printf '  %s\n' "${TO_DELETE[@]}"
+
+if [[ "$APPLY" != true ]]; then
+  echo
+  echo "Dry-run only. Re-run with --apply to delete on GitHub."
+  exit 0
+fi
+
+for b in "${TO_DELETE[@]}"; do
+  if gh api -X DELETE "repos/$REPO/git/refs/heads/$b" >/dev/null 2>&1; then
+    echo "deleted: $b"
+  else
+    echo "skip: $b (missing or protected)"
+  fi
+done
+
+echo "Done. Enable delete_branch_on_merge in GitHub repo Settings → General if not already on."

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,6 @@
 {
   "github": {
-    "silent": true,
-    "autoJobCancelation": true
+    "silent": true
   },
   "ignoreCommand": "bash scripts/vercel-should-build.sh",
   "framework": "nextjs"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cleans up leftover duplication from the triple-Vercel-project era and reduces future branch/deploy churn.

## What changed

### Git (already applied on GitHub)
Deleted **18 stale remote branches**, including:
- Duplicate `master`
- Deploy trigger branches (`chore/trigger-deploy`, `fix/env-redeploy`)
- All abandoned `cursor/*` agent branches
- Other fully-merged branches (`feat/chat-firestore-memory-admin`, `hotfix/error-my-work-refactor`, etc.)

Remote branch count: **44 → 26**. No `cursor/*` branches remain.

### Repo changes (this PR)
- **`scripts/git-cleanup-stale-branches.sh`** — dry-run / `--apply` helper for ongoing hygiene
- **`vercel.json`** — removed `autoJobCancelation` so rapid merges don't cancel in-flight production builds
- **`docs/VERCEL-CLEANUP.md`** / **`docs/VERCEL-DEPLOY.md`** — docs updated to reflect single-project, main-only deploys

## Manual step (needs repo admin)

Enable **Automatically delete head branches** in GitHub → Settings → General (API token lacked permission to toggle this).

## Notes

- Old GitHub Deployment rows (`Production – lgportfolio-inline`, etc.) are historical and harmless — they cannot be deleted.
- Vercel duplicate projects were already removed; this PR does not recreate them.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eace6395-f15d-4ad2-be14-8eed503f29c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eace6395-f15d-4ad2-be14-8eed503f29c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

