### PR TITLE
fix(chat): fall back to OpenRouter when Inferencia returns 502

### DIFF
--- a/src/__tests__/chat-providers.test.ts
+++ b/src/__tests__/chat-providers.test.ts
@@ -21,9 +21,18 @@ import {
   streamChatWithFallbacks,
 } from "@/lib/chat-providers";
 
+function mockStreamResult(text = "hello") {
+  return {
+    textStream: (async function* () {
+      yield text;
+    })(),
+    toTextStreamResponse: vi.fn(),
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
-  mockStreamText.mockResolvedValue({ toTextStreamResponse: vi.fn() });
+  mockStreamText.mockReturnValue(mockStreamResult());
   vi.stubEnv("INFERENCIA_API_KEY", "inf-key");
   vi.stubEnv("INFERENCIA_BASE_URL", "https://inferencia.test/v1");
   vi.stubEnv("INFERENCIA_CHAT_MODEL", "gemma4:e4b");
@@ -57,10 +66,15 @@ describe("chat-providers", () => {
     expect(isChatConfigured()).toBe(true);
   });
 
-  it("falls back to openrouter when inferencia fails", async () => {
+  it("falls back to openrouter when inferencia stream throws (e.g. 502)", async () => {
     mockStreamText
-      .mockRejectedValueOnce(new Error("connection refused"))
-      .mockResolvedValueOnce({ toTextStreamResponse: vi.fn() });
+      .mockReturnValueOnce({
+        textStream: (async function* () {
+          throw new Error("Bad Gateway");
+        })(),
+        toTextStreamResponse: vi.fn(),
+      })
+      .mockReturnValueOnce(mockStreamResult("from openrouter"));
 
     const fallbacks: string[] = [];
     const result = await streamChatWithFallbacks(
@@ -73,8 +87,51 @@ describe("chat-providers", () => {
     expect(result.provider).toBe("openrouter");
   });
 
+  it("falls back to openrouter when inferencia returns an empty stream", async () => {
+    mockStreamText
+      .mockReturnValueOnce({
+        textStream: (async function* () {})(),
+        toTextStreamResponse: vi.fn(),
+      })
+      .mockReturnValueOnce(mockStreamResult("from openrouter"));
+
+    const result = await streamChatWithFallbacks({
+      system: "sys",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(mockStreamText).toHaveBeenCalledTimes(2);
+    expect(result.provider).toBe("openrouter");
+  });
+
+  it("falls back when inferencia times out before first token", async () => {
+    vi.useFakeTimers();
+    mockStreamText
+      .mockReturnValueOnce({
+        textStream: (async function* () {
+          await new Promise(() => {});
+        })(),
+        toTextStreamResponse: vi.fn(),
+      })
+      .mockReturnValueOnce(mockStreamResult("from openrouter"));
+
+    const promise = streamChatWithFallbacks({
+      system: "sys",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    await vi.advanceTimersByTimeAsync(18_000);
+    const result = await promise;
+
+    expect(mockStreamText).toHaveBeenCalledTimes(2);
+    expect(result.provider).toBe("openrouter");
+    vi.useRealTimers();
+  });
+
   it("throws when all providers fail", async () => {
-    mockStreamText.mockRejectedValue(new Error("down"));
+    mockStreamText.mockReturnValue({
+      textStream: (async function* () {})(),
+      toTextStreamResponse: vi.fn(),
+    });
     await expect(
       streamChatWithFallbacks({ system: "sys", messages: [{ role: "user", content: "hi" }] })
     ).rejects.toThrow(/All chat providers failed/);

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -378,6 +378,14 @@ ${context}`;
       trace_id: traceId,
     });
     log("ERROR", "Chat API error", { trace_id: traceId, error: msg, latency_ms: duration });
-    return jsonError(503, "Service unavailable", "The AI is temporarily unavailable. Try again later or email luisgimenezdev@gmail.com.");
+    const hint =
+      !process.env.OPENROUTER_API_KEY?.trim() && process.env.INFERENCIA_API_KEY?.trim()
+        ? " Inferencia is down and no cloud fallback (OPENROUTER_API_KEY) is configured."
+        : "";
+    return jsonError(
+      503,
+      "Service unavailable",
+      `The AI is temporarily unavailable.${hint} Try again later or email luisgimenezdev@gmail.com.`
+    );
   }
 }

--- a/src/lib/chat-providers.ts
+++ b/src/lib/chat-providers.ts
@@ -110,6 +110,41 @@ function remainingBudgetMs(startedAt: number): number {
   return Math.max(0, TOTAL_INFERENCE_BUDGET_MS - (Date.now() - startedAt));
 }
 
+function formatProviderError(error: unknown): string {
+  if (error instanceof Error) {
+    const retry = error as Error & { reason?: string; lastError?: Error };
+    if (retry.reason === "maxRetriesExceeded" && retry.lastError) {
+      return retry.lastError.message;
+    }
+    return error.message;
+  }
+  return String(error);
+}
+
+/** streamText() returns immediately; gate on first token so 502s reach the fallback loop. */
+async function awaitFirstTextDelta(
+  result: { textStream: AsyncIterable<string> },
+  timeoutMs: number
+): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error("Inference timeout")), timeoutMs);
+  });
+
+  const firstDelta = (async () => {
+    for await (const delta of result.textStream) {
+      if (delta.length > 0) return;
+    }
+    throw new Error("Empty inference stream");
+  })();
+
+  try {
+    await Promise.race([firstDelta, timeoutPromise]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
 export async function streamChatWithFallbacks(
   params: StreamChatParams,
   options?: { onAttempt?: (provider: ChatProviderSpec) => void; onFallback?: (from: ChatProviderSpec, error: string) => void }
@@ -131,7 +166,7 @@ export async function streamChatWithFallbacks(
 
     try {
       const client = provider.createClient();
-      const result = await streamText({
+      const result = streamText({
         model: client.chat(provider.model),
         system: params.system,
         messages: params.messages,
@@ -140,9 +175,10 @@ export async function streamChatWithFallbacks(
         temperature: params.temperature ?? 0.5,
         abortSignal: AbortSignal.timeout(timeoutMs),
       });
+      await awaitFirstTextDelta(result, timeoutMs);
       return { result, provider: provider.id, model: provider.model };
     } catch (error) {
-      lastError = error instanceof Error ? error.message : String(error);
+      lastError = formatProviderError(error);
       options?.onFallback?.(provider, lastError);
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Inferencia (`llm.menezmethod.com`) is returning **502 Bad Gateway** (Cloudflare — host down). Chat fails with:

```
AI_RetryError: Failed after 2 attempts. Last error: Bad Gateway
url: https://llm.menezmethod.com/v1/chat/completions
```

The OpenRouter fallback chain never ran because `streamText()` returns **before** the upstream HTTP call completes. The 502 only surfaced when the client read the stream — after we had already committed to Inferencia.

## Fix

- **Gate on first text delta** before returning from `streamChatWithFallbacks` — 502/timeout/empty stream triggers fallback
- **`formatProviderError`** — unwrap `AI_RetryError` to the underlying message
- **Clearer 503** when Inferencia is down and `OPENROUTER_API_KEY` is not set in Vercel

## Required for fallback to work in production

Set `OPENROUTER_API_KEY` in Vercel (production):

```bash
export VERCEL_TOKEN=...
export OPENROUTER_API_KEY=...
./scripts/vercel-add-openrouter-env.sh
```

Without that env var, only Inferencia is in the provider chain.

## Inferencia host

Restart/fix `llm.menezmethod.com` on the Pi (Ollama/Inferencia tunnel). Chat will work via OpenRouter until it's back.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eace6395-f15d-4ad2-be14-8eed503f29c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eace6395-f15d-4ad2-be14-8eed503f29c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

