### PR TITLE
test(war-room): consolidate open PRs — explain-error model test from #66

### DIFF
--- a/src/__tests__/api-war-room.test.ts
+++ b/src/__tests__/api-war-room.test.ts
@@ -150,6 +150,15 @@ describe("/api/war-room/explain-error", () => {
         })
       );
     });
+
+    it("uses gemma4:e4b when INFERENCIA_CHAT_MODEL is unset", async () => {
+      vi.stubEnv("INFERENCIA_API_KEY", "test-key");
+      delete process.env.INFERENCIA_CHAT_MODEL;
+
+      await explainError(makeExplainRequest({ error_text: "test error" }));
+
+      expect(mockChat).toHaveBeenCalledWith("gemma4:e4b");
+    });
   });
 
   describe("rate limiting", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reviews and consolidates the 6 open PRs against current `main` (post-#81).

### Merged via this PR

- **#66** — War-room `explain-error` already uses `gemma4:e4b` on `main`; this adds the missing unit test.

### Close manually (superseded by #81)

These are duplicate first-token gating attempts — **do not merge**:

| PR | Title |
|----|-------|
| #74 | gate stream on first token |
| #76 | gate OpenRouter fallback on first text token |
| #78 | gate OpenRouter fallback on first text token |
| #80 | gate provider fallback on first text token (conflicts) |

```bash
gh pr close 74 76 78 80
```

### Hold (#68) — do not merge yet

**[LGP-004] GCP Cloud Run deployment pipeline** — adds GCP PR preview Cloud Run services. Conflicts with Vercel-primary + main-only deploy policy. Revisit only if switching production back to GCP.

```bash
gh pr close 68   # or leave open as draft for rollback path
```

## Solidified state on `main`

- Chat: Inferencia → OpenRouter fallback (#81)
- Vercel: one project, main-only production (#79)
- War-room explain-error: `gemma4:e4b` default (this PR adds test)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eace6395-f15d-4ad2-be14-8eed503f29c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eace6395-f15d-4ad2-be14-8eed503f29c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

