### PR TITLE
fix(ops): Hermes automation guards + Coolify Inferencia hardening

### DIFF
--- a/.env.coolify.example
+++ b/.env.coolify.example
@@ -1,0 +1,22 @@
+# Coolify / Pi homelab — copy to .env.coolify on the host (never commit .env.coolify).
+# Values here match docker-compose.coolify.yml defaults; Coolify UI env must match.
+
+# --- Inferencia (same Docker network as lgportfolio) ---
+INFERENCIA_BASE_URL=http://inferencia:8080/v1
+# Must match inferencia container API_KEYS (docker exec inferencia env | grep API_KEYS)
+INFERENCIA_API_KEY=replace-with-inferencia-api-key
+INFERENCIA_CHAT_MODEL=gemma4:12b
+
+# --- Optional cloud fallback when Inferencia is down ---
+# OPENROUTER_API_KEY=sk-or-v1-...
+
+# --- App ---
+ADMIN_SECRET=replace-with-admin-secret
+NEXT_PUBLIC_SITE_URL=https://gimenez.dev
+COOLIFY=1
+
+# --- Observability (War Room aggregates from Prometheus on coolify network) ---
+PROMETHEUS_URL=http://prometheus-prometheus-1:9090
+
+# --- Rate limits (optional) ---
+# CHAT_DAILY_BUDGET=150

--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ GOOGLE_API_KEY=your-gemini-api-key-here
 # =============================================================================
 INFERENCIA_API_KEY=your-inferencia-api-key-here
 INFERENCIA_BASE_URL=http://localhost:8080/v1
-INFERENCIA_CHAT_MODEL=your-model-name
+INFERENCIA_CHAT_MODEL=gemma4:12b
 
 # =============================================================================
 # OPENROUTER — Cloud fallback when Inferencia is down (free models)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,8 @@ jobs:
             -d "{\"git_commit_sha\":\"${GIT_SHA}\"}" \
             "${COOLIFY_URL%/}/api/v1/applications/${COOLIFY_APP_UUID}"
 
-          echo "Triggering Coolify deploy"
+          echo "Triggering Coolify deploy (lgportfolio app only — never inferencia/ollama)"
+          # COOLIFY_APP_UUID must be the lgportfolio application in Coolify UI, not inferencia.
           curl -fsSL -X GET \
             -H "Authorization: Bearer ${COOLIFY_API_TOKEN}" \
             -H "Accept: application/json" \

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -30,10 +30,11 @@ services:
       PORT: "3000"
       HOSTNAME: "0.0.0.0"
       COOLIFY: "1"
-      # Same-host services on the coolify network (override in .env.coolify if needed)
-      INFERENCIA_BASE_URL: ${INFERENCIA_BASE_URL:-http://inferencia:8080/v1}
-      PROMETHEUS_URL: ${PROMETHEUS_URL:-http://prometheus-prometheus-1:9090}
-      NEXT_PUBLIC_SITE_URL: ${NEXT_PUBLIC_SITE_URL:-https://gimenez.dev}
+      # Pinned defaults — override only by editing this file + redeploy (not Coolify UI drift)
+      INFERENCIA_BASE_URL: "http://inferencia:8080/v1"
+      INFERENCIA_CHAT_MODEL: "gemma4:12b"
+      PROMETHEUS_URL: "http://prometheus-prometheus-1:9090"
+      NEXT_PUBLIC_SITE_URL: "https://gimenez.dev"
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health/live"]
       interval: 30s

--- a/docs/DEPLOY-COOLIFY.md
+++ b/docs/DEPLOY-COOLIFY.md
@@ -101,6 +101,32 @@ curl -s https://gimenez.dev/api/war-room/data | python3 -c "import sys,json; d=j
 
 War Room should show `metrics_source: prometheus` and Prometheus **UP**.
 
+## Hermes & automations (do not break Inferencia)
+
+After each `git pull` on the Pi:
+
+```bash
+./scripts/hermes/install-watchdogs.sh   # sync safe watchdogs to ~/.hermes
+./scripts/hermes/audit-automations.sh   # fail if unsafe crons/scripts exist
+```
+
+**Safe (report-only):**
+
+| Automation | What it does |
+|------------|----------------|
+| `inferencia-watchdog.py` | GET Inferencia `/health` + shallow `/api/health` |
+| `portfolio-chat-watchdog.sh` | Same; never POST `/api/chat` |
+| GitHub Actions `deploy` job | Redeploys **lgportfolio** Coolify app only (after CI) |
+
+**Never automate (caused outages):**
+
+- POST `https://gimenez.dev/api/chat` on a cron
+- `docker restart` / Coolify redeploy on **inferencia** or **ollama**
+- Hermes auto-recovery (`WATCHDOG_ENABLE_RECOVERY`) — permanently disabled in v2 scripts
+- Vercel `vercel --prod` from crons
+
+Policy reference: `scripts/hermes/policy.json`. Example crons: every **15 min**, `no_agent: true`.
+
 ## Rollback to Vercel
 
 Point Namecheap `@` / `www` back to Vercel (`76.76.21.21` / `cname.vercel-dns.com`). See [VERCEL-DEPLOY.md](./VERCEL-DEPLOY.md).

--- a/docs/DEPLOY-COOLIFY.md
+++ b/docs/DEPLOY-COOLIFY.md
@@ -83,7 +83,7 @@ Enable **API** in Coolify if disabled: **Settings** → enable API access for to
 | `INFERENCIA_BASE_URL` | `http://inferencia:8080/v1` |
 | `PROMETHEUS_URL` | `http://prometheus-prometheus-1:9090` |
 | `INFERENCIA_API_KEY` | Same key as inferencia service |
-| `INFERENCIA_CHAT_MODEL` | `gemma4:e4b` |
+| `INFERENCIA_CHAT_MODEL` | `gemma4:12b` (pinned in `docker-compose.coolify.yml`; do not use `gemma4:e4b`) |
 | `ADMIN_SECRET` | Your admin secret |
 | `NEXT_PUBLIC_SITE_URL` | `https://gimenez.dev` |
 | `COOLIFY` | `1` |
@@ -91,6 +91,10 @@ Enable **API** in Coolify if disabled: **Settings** → enable API access for to
 ## Verify
 
 ```bash
+# On Pi — full RCA (auth, model, network, chat POST)
+chmod +x scripts/verify-coolify-chat.sh
+./scripts/verify-coolify-chat.sh
+
 curl -s https://gimenez.dev/api/health | python3 -m json.tool
 curl -s https://gimenez.dev/api/war-room/data | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['metrics_source'], d.get('service_status',{}).get('checks',{}).get('prometheus'))"
 ```

--- a/scripts/deploy-coolify.sh
+++ b/scripts/deploy-coolify.sh
@@ -124,6 +124,11 @@ for i in $(seq 1 30); do
   fi
 done
 
+echo "==> Verifying chat chain (auth + model)"
+ssh "$HOST" "chmod +x ${REMOTE_DIR}/scripts/verify-coolify-chat.sh && ENV_FILE=${REMOTE_DIR}/.env.coolify ${REMOTE_DIR}/scripts/verify-coolify-chat.sh" || {
+  echo "WARN: verify-coolify-chat failed — fix INFERENCIA_API_KEY in .env.coolify (must match inferencia API_KEYS)"
+}
+
 echo ""
 echo "Deploy complete. DNS step (Namecheap):"
 echo "  A  @   → 47.203.87.233  (home public IP — traefik issues Let's Encrypt cert)"

--- a/scripts/hermes/audit-automations.sh
+++ b/scripts/hermes/audit-automations.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Audit Hermes + local crons for patterns that break Inferencia / chat.
+# Run on Pi after install or when debugging: ./scripts/hermes/audit-automations.sh
+#
+# Exit 0 = clean | Exit 1 = dangerous patterns found (prints report)
+
+set -euo pipefail
+
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+ISSUES=0
+
+warn() {
+  echo "UNSAFE: $*"
+  ISSUES=$((ISSUES + 1))
+}
+
+ok() {
+  echo "OK: $*"
+}
+
+scan_file() {
+  local f="$1"
+  [ -f "$f" ] || return 0
+  local rel="${f#$HERMES_HOME/}"
+
+  if rg -qi 'POST.*(/api/chat|chat/completions)' "$f" 2>/dev/null; then
+    warn "$rel — POST /api/chat (loads Ollama, rate limits)"
+  fi
+  if rg -qi 'docker\s+(restart|rm|stop|kill).*(inferencia|ollama)' "$f" 2>/dev/null; then
+    warn "$rel — docker restart/stop inferencia or ollama (502 storms)"
+  fi
+  if rg -qi 'coolify.*(restart|redeploy|deploy).*inferencia' "$f" 2>/dev/null; then
+    warn "$rel — Coolify redeploy inferencia"
+  fi
+  if rg -qi 'WATCHDOG_ENABLE_RECOVERY\s*=\s*(1|true|yes)' "$f" 2>/dev/null; then
+    warn "$rel — auto-recovery enabled"
+  fi
+  if rg -qi 'vercel\s+(--prod|rollback)' "$f" 2>/dev/null; then
+    warn "$rel — Vercel prod deploy/rollback from cron"
+  fi
+}
+
+echo "=== Hermes / automation safety audit ==="
+echo "HERMES_HOME=$HERMES_HOME"
+echo
+
+if [ ! -d "$HERMES_HOME" ]; then
+  echo "WARN: $HERMES_HOME not found — nothing to audit"
+  exit 0
+fi
+
+# Required safe scripts (from install-watchdogs.sh)
+for required in scripts/inferencia-watchdog.py scripts/portfolio-chat-watchdog.sh; do
+  if [ -f "$HERMES_HOME/$required" ]; then
+    ok "installed $required"
+  else
+    warn "missing $required — run ./scripts/hermes/install-watchdogs.sh"
+  fi
+done
+
+# Scan all Hermes scripts and cron definitions
+while IFS= read -r -d '' f; do
+  scan_file "$f"
+done < <(find "$HERMES_HOME" -type f \( -name '*.sh' -o -name '*.py' -o -name '*.json' -o -name '*.yaml' -o -name '*.yml' \) -print0 2>/dev/null)
+
+# Crontab entries referencing hermes (user crontab only)
+if crontab -l 2>/dev/null | rg -i 'hermes|inferencia-watchdog|portfolio-chat' >/tmp/hermes-cron.txt 2>/dev/null; then
+  echo "--- crontab (hermes-related) ---"
+  cat /tmp/hermes-cron.txt
+  while IFS= read -r line; do
+    case "$line" in \#*|"") continue ;; esac
+    if echo "$line" | rg -qi 'api/chat|docker restart|enable_recovery'; then
+      warn "crontab: $line"
+    else
+      ok "crontab: $line"
+    fi
+  done < /tmp/hermes-cron.txt
+fi
+
+echo
+if [ "$ISSUES" -gt 0 ]; then
+  echo "FAILED: $ISSUES unsafe pattern(s). Fix or remove before enabling crons."
+  echo "Safe watchdogs: GET /health only, shallow /api/health, interval >= 10 min, no_agent: true"
+  exit 1
+fi
+
+echo "PASSED: no unsafe automation patterns detected."
+exit 0

--- a/scripts/hermes/inferencia-watchdog.py
+++ b/scripts/hermes/inferencia-watchdog.py
@@ -32,6 +32,14 @@ TIMEOUT = float(os.getenv("WATCHDOG_TIMEOUT", "8"))
 RECOVERY_ENABLED = os.getenv("WATCHDOG_ENABLE_RECOVERY", "").lower() in ("1", "true", "yes")
 USER_AGENT = "hermes-inferencia-watchdog/2"
 
+# Hard block — recovery caused 502 storms; report-only forever.
+if RECOVERY_ENABLED:
+    print(
+        "inferencia-watchdog: WATCHDOG_ENABLE_RECOVERY is set but permanently disabled — "
+        "fix manually; do not auto-restart inferencia/ollama",
+        file=sys.stderr,
+    )
+
 
 def fetch_json(url: str, headers: dict[str, str] | None = None) -> tuple[int, dict | None]:
     merged = {"User-Agent": USER_AGENT, **(headers or {})}
@@ -67,11 +75,7 @@ def main() -> int:
 
     if errors:
         print("inferencia-watchdog: " + "; ".join(errors))
-        if RECOVERY_ENABLED:
-            print(
-                "inferencia-watchdog: auto-recovery is disabled — "
-                "unset WATCHDOG_ENABLE_RECOVERY and fix manually"
-            )
+        print("inferencia-watchdog: report-only — no auto-restart (fix manually on Pi)")
 
     return 0
 

--- a/scripts/hermes/install-watchdogs.sh
+++ b/scripts/hermes/install-watchdogs.sh
@@ -20,6 +20,15 @@ mkdir -p "$DEST"
 
 install -m 755 "$REPO_ROOT/scripts/hermes/inferencia-watchdog.py" "$DEST/inferencia-watchdog.py"
 install -m 755 "$REPO_ROOT/scripts/hermes-chat-watchdog.sh" "$DEST/portfolio-chat-watchdog.sh"
+install -m 644 "$REPO_ROOT/scripts/hermes/policy.json" "$DEST/policy.json"
+install -m 755 "$REPO_ROOT/scripts/hermes/audit-automations.sh" "$DEST/audit-automations.sh"
+
+echo "Running safety audit..."
+if "$DEST/audit-automations.sh"; then
+  echo "Audit passed."
+else
+  echo "WARN: audit found unsafe patterns — review ~/.hermes and crontab (see policy.json)"
+fi
 
 cat <<EOF
 Installed safe watchdogs to ${DEST}:

--- a/scripts/hermes/policy.json
+++ b/scripts/hermes/policy.json
@@ -1,0 +1,38 @@
+{
+  "policy_version": 2,
+  "description": "Hermes cron policy for gimenez.dev + Inferencia — report-only, no recovery",
+  "rules": {
+    "allowed_http": ["GET /health", "GET /api/health?shallow=1", "HEAD /api/chat"],
+    "forbidden_http": ["POST /api/chat", "POST /v1/chat/completions"],
+    "forbidden_actions": [
+      "docker restart inferencia",
+      "docker restart ollama",
+      "coolify redeploy inferencia",
+      "vercel --prod",
+      "WATCHDOG_ENABLE_RECOVERY"
+    ],
+    "min_interval_minutes": 10,
+    "no_agent": true
+  },
+  "recommended_crons": [
+    {
+      "name": "inferencia-watchdog",
+      "schedule": "*/15 * * * *",
+      "command": "python3 ~/.hermes/scripts/inferencia-watchdog.py",
+      "no_agent": true,
+      "notes": "GET /health + shallow portfolio health only"
+    },
+    {
+      "name": "portfolio-chat-watchdog",
+      "schedule": "*/15 * * * *",
+      "command": "bash ~/.hermes/scripts/portfolio-chat-watchdog.sh",
+      "no_agent": true,
+      "notes": "No POST /api/chat"
+    }
+  ],
+  "github_actions": {
+    "deploy_target": "lgportfolio Coolify app only",
+    "never_deploy": ["inferencia", "ollama", "cloudflared"],
+    "secrets": ["COOLIFY_APP_UUID must be lgportfolio application UUID"]
+  }
+}

--- a/scripts/verify-coolify-chat.sh
+++ b/scripts/verify-coolify-chat.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Run on Pi (or: ssh pico-infra 'bash -s' < scripts/verify-coolify-chat.sh)
+# Diagnoses "Server temporarily unavailable" — auth, model, and network.
+set -euo pipefail
+
+ENV_FILE="${ENV_FILE:-/home/menez/apps/lgportfolio/.env.coolify}"
+CONTAINER="${CONTAINER:-lgportfolio}"
+
+fail() { echo "FAIL: $*"; exit 1; }
+ok() { echo "OK: $*"; }
+
+echo "=== Coolify chat RCA ==="
+
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  set -a && source "$ENV_FILE" && set +a
+  ok "loaded $ENV_FILE"
+else
+  echo "WARN: $ENV_FILE not found — using container env"
+fi
+
+BASE="${INFERENCIA_BASE_URL:-http://inferencia:8080/v1}"
+ORIGIN="${BASE%/v1}"
+ORIGIN="${ORIGIN%/}"
+MODEL="${INFERENCIA_CHAT_MODEL:-gemma4:12b}"
+KEY="${INFERENCIA_API_KEY:-}"
+
+echo "INFERENCIA_BASE_URL=$BASE"
+echo "INFERENCIA_CHAT_MODEL=$MODEL"
+echo "INFERENCIA_API_KEY set: $([ -n "$KEY" ] && echo yes || echo NO)"
+
+# 1. Inferencia /health (no auth)
+code=$(curl -sS -o /tmp/inf-health.json -w '%{http_code}' --max-time 8 "${ORIGIN}/health" || echo 000)
+[ "$code" = "200" ] || fail "Inferencia /health HTTP $code"
+python3 -c "
+import json,sys
+d=json.load(open('/tmp/inf-health.json'))
+models=[m['id'] for m in d.get('services',{}).get('ollama',{}).get('models',[])]
+print('ollama models:', ', '.join(models[:8]), '...' if len(models)>8 else '')
+model='$MODEL'
+if model not in models:
+    print(f'WARN: configured model {model!r} not in Ollama list')
+else:
+    print(f'model {model!r} present')
+"
+
+# 2. Auth — /v1/models requires Bearer key
+if [ -z "$KEY" ]; then
+  fail "INFERENCIA_API_KEY empty in $ENV_FILE"
+fi
+code=$(curl -sS -o /tmp/inf-models.json -w '%{http_code}' --max-time 8 \
+  -H "Authorization: Bearer ${KEY}" \
+  "${ORIGIN}/v1/models" || echo 000)
+[ "$code" = "200" ] || fail "/v1/models auth HTTP $code (key mismatch with inferencia API_KEYS?)"
+
+# 3. lgportfolio container env (Coolify may override .env.coolify)
+if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER}$"; then
+  echo "--- container env (lgportfolio) ---"
+  docker exec "$CONTAINER" sh -c 'echo INFERENCIA_BASE_URL=$INFERENCIA_BASE_URL; echo INFERENCIA_CHAT_MODEL=$INFERENCIA_CHAT_MODEL; test -n "$INFERENCIA_API_KEY" && echo INFERENCIA_API_KEY=set || echo INFERENCIA_API_KEY=MISSING'
+  docker exec "$CONTAINER" wget -qO- --timeout=8 http://inferencia:8080/health >/dev/null \
+    && ok "lgportfolio → inferencia:8080 reachable" \
+    || fail "lgportfolio cannot reach inferencia:8080 (coolify network?)"
+else
+  echo "WARN: container $CONTAINER not running"
+fi
+
+# 4. Site chat (from Pi)
+code=$(curl -sS -o /tmp/chat.json -w '%{http_code}' --max-time 60 -X POST http://127.0.0.1:3000/api/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"messages":[{"role":"user","content":"ping"}]}' 2>/dev/null || echo 000)
+if [ "$code" = "200" ]; then
+  ok "POST /api/chat HTTP 200"
+else
+  echo "FAIL: POST /api/chat HTTP $code"
+  cat /tmp/chat.json 2>/dev/null || true
+  exit 1
+fi
+
+ok "chat chain healthy"

--- a/src/__tests__/api-war-room.test.ts
+++ b/src/__tests__/api-war-room.test.ts
@@ -100,6 +100,10 @@ describe("/api/war-room/data", () => {
 // ── Explain Error (Inferencia) ──────────────────────────────────────────────
 
 describe("/api/war-room/explain-error", () => {
+  beforeEach(() => {
+    vi.stubEnv("INFERENCIA_BASE_URL", "https://inference.example.com/v1");
+  });
+
   describe("Inferencia configuration", () => {
     it("returns 503 when INFERENCIA_API_KEY is missing", async () => {
       delete process.env.INFERENCIA_API_KEY;

--- a/src/__tests__/api-war-room.test.ts
+++ b/src/__tests__/api-war-room.test.ts
@@ -151,13 +151,13 @@ describe("/api/war-room/explain-error", () => {
       );
     });
 
-    it("uses gemma4:e4b when INFERENCIA_CHAT_MODEL is unset", async () => {
+    it("uses gemma4:12b when INFERENCIA_CHAT_MODEL is unset", async () => {
       vi.stubEnv("INFERENCIA_API_KEY", "test-key");
       delete process.env.INFERENCIA_CHAT_MODEL;
 
       await explainError(makeExplainRequest({ error_text: "test error" }));
 
-      expect(mockChat).toHaveBeenCalledWith("gemma4:e4b");
+      expect(mockChat).toHaveBeenCalledWith("gemma4:12b");
     });
   });
 

--- a/src/__tests__/chat-providers.test.ts
+++ b/src/__tests__/chat-providers.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
   mockStreamText.mockReturnValue(mockStreamResult());
   vi.stubEnv("INFERENCIA_API_KEY", "inf-key");
   vi.stubEnv("INFERENCIA_BASE_URL", "https://inferencia.test/v1");
-  vi.stubEnv("INFERENCIA_CHAT_MODEL", "gemma4:e4b");
+  vi.stubEnv("INFERENCIA_CHAT_MODEL", "gemma4:12b");
   vi.stubEnv("OPENROUTER_API_KEY", "or-key");
 });
 
@@ -53,7 +53,7 @@ describe("chat-providers", () => {
   it("builds inferencia first then openrouter fallbacks", () => {
     const chain = buildChatProviderChain();
     expect(chain[0].id).toBe("inferencia");
-    expect(chain[0].model).toBe("gemma4:e4b");
+    expect(chain[0].model).toBe("gemma4:12b");
     expect(chain[1].id).toBe("openrouter");
     expect(chain[1].model).toBe(OPENROUTER_FREE_FALLBACK_MODELS[0]);
     expect(chain.length).toBe(1 + OPENROUTER_FREE_FALLBACK_MODELS.length);
@@ -83,7 +83,7 @@ describe("chat-providers", () => {
     );
 
     expect(mockStreamText).toHaveBeenCalledTimes(2);
-    expect(fallbacks).toContain("gemma4:e4b");
+    expect(fallbacks).toContain("gemma4:12b");
     expect(result.provider).toBe("openrouter");
   });
 

--- a/src/__tests__/inferencia-config.test.ts
+++ b/src/__tests__/inferencia-config.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  DEFAULT_INFERENCIA_CHAT_MODEL,
+  DEFAULT_INFERENCIA_BASE_URL_COOLIFY,
+  getInferenciaChatModel,
+  getInferenciaBaseUrl,
+  inferenciaModelsUrl,
+} from "@/lib/inferencia-config";
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("inferencia-config", () => {
+  it("defaults chat model to gemma4:12b", () => {
+    delete process.env.INFERENCIA_CHAT_MODEL;
+    expect(getInferenciaChatModel()).toBe(DEFAULT_INFERENCIA_CHAT_MODEL);
+    expect(DEFAULT_INFERENCIA_CHAT_MODEL).toBe("gemma4:12b");
+  });
+
+  it("uses COOLIFY default base URL when env unset", () => {
+    delete process.env.INFERENCIA_BASE_URL;
+    vi.stubEnv("COOLIFY", "1");
+    expect(getInferenciaBaseUrl()).toBe(DEFAULT_INFERENCIA_BASE_URL_COOLIFY);
+  });
+
+  it("builds models URL from base URL", () => {
+    expect(inferenciaModelsUrl("http://inferencia:8080/v1")).toBe("http://inferencia:8080/v1/models");
+  });
+});

--- a/src/__tests__/inferencia-health.test.ts
+++ b/src/__tests__/inferencia-health.test.ts
@@ -7,6 +7,7 @@ beforeEach(() => {
   resetInferenciaHealthCache();
   vi.stubEnv("INFERENCIA_API_KEY", "test-key");
   vi.stubEnv("INFERENCIA_BASE_URL", "https://llm.example.com/v1");
+  vi.stubEnv("INFERENCIA_CHAT_MODEL", "gemma4:12b");
 });
 
 afterEach(() => {
@@ -22,19 +23,56 @@ describe("probeInferenciaHealth", () => {
     expect(result.status).toBe("degraded");
   });
 
-  it("returns up when Inferencia /health responds healthy", async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ status: "healthy" }),
-    } as Response);
+  it("returns up when /health and authenticated /v1/models succeed", async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (String(url).endsWith("/health")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            status: "healthy",
+            services: { ollama: { models: [{ id: "gemma4:12b" }] } },
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ data: [] }) } as Response);
+    });
 
     const result = await probeInferenciaHealth();
     expect(result.status).toBe("up");
-    expect(result.latency_ms).toBeDefined();
-    expect(global.fetch).toHaveBeenCalledWith(
-      "https://llm.example.com/health",
-      expect.objectContaining({ signal: expect.any(AbortSignal) })
-    );
+    expect(result.model).toBe("gemma4:12b");
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns down when API key is rejected on /v1/models", async () => {
+    global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (String(url).endsWith("/health")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            status: "healthy",
+            services: { ollama: { models: [{ id: "gemma4:12b" }] } },
+          }),
+        } as Response);
+      }
+      expect(init?.headers).toMatchObject({ Authorization: "Bearer test-key" });
+      return Promise.resolve({ ok: false, json: async () => ({}) } as Response);
+    });
+
+    const result = await probeInferenciaHealth();
+    expect(result.status).toBe("down");
+  });
+
+  it("returns down when configured model is not loaded in Ollama", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: "healthy",
+        services: { ollama: { models: [{ id: "gemma4:e4b" }] } },
+      }),
+    } as Response);
+
+    const result = await probeInferenciaHealth();
+    expect(result.status).toBe("down");
   });
 
   it("returns down when Inferencia /health is unreachable", async () => {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -380,7 +380,7 @@ ${context}`;
     log("ERROR", "Chat API error", { trace_id: traceId, error: msg, latency_ms: duration });
     const hint =
       !process.env.OPENROUTER_API_KEY?.trim() && process.env.INFERENCIA_API_KEY?.trim()
-        ? " Inferencia is down and no cloud fallback (OPENROUTER_API_KEY) is configured."
+        ? " Check Inferencia API key matches inferencia container API_KEYS (run scripts/verify-coolify-chat.sh on Pi)."
         : "";
     return jsonError(
       503,

--- a/src/app/api/war-room/explain-error/route.ts
+++ b/src/app/api/war-room/explain-error/route.ts
@@ -1,5 +1,6 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import { generateText } from "ai";
+import { getInferenciaApiKey, getInferenciaBaseUrl, getInferenciaChatModel } from "@/lib/inferencia-config";
 import {
   checkRateLimit,
   incrementDailyCount,
@@ -9,16 +10,13 @@ import { publishDailyBudgetGauge, recordRequest } from "@/lib/telemetry";
 
 export const maxDuration = 30;
 
-const DEFAULT_BASE_URL = process.env.INFERENCIA_BASE_URL || "";
-const DEFAULT_CHAT_MODEL = "gemma4:e4b";
-
 const SYSTEM_PROMPT = `You are a DevOps/SRE assistant. The user will paste an error message or log line from their application.
 Your job: explain what the error means in plain language and suggest 1–3 concrete fixes. Be concise (under 150 words).
 Do not make up stack traces or code. If the error is unclear, say so and suggest how to get more context (e.g. check logs, trace_id).`;
 
 export async function POST(req: Request) {
   const start = Date.now();
-  const apiKey = process.env.INFERENCIA_API_KEY;
+  const apiKey = getInferenciaApiKey();
   if (!apiKey) {
     recordRequest("/api/war-room/explain-error", "POST", 503, Date.now() - start);
     return new Response(
@@ -57,8 +55,15 @@ export async function POST(req: Request) {
       );
     }
 
-    const baseURL = process.env.INFERENCIA_BASE_URL || DEFAULT_BASE_URL;
-    const model = process.env.INFERENCIA_CHAT_MODEL || DEFAULT_CHAT_MODEL;
+    const baseURL = getInferenciaBaseUrl();
+    const model = getInferenciaChatModel();
+    if (!baseURL || !apiKey) {
+      recordRequest("/api/war-room/explain-error", "POST", 503, Date.now() - start);
+      return new Response(
+        JSON.stringify({ error: "Inference API not configured" }),
+        { status: 503, headers: { "Content-Type": "application/json", "X-Content-Type-Options": "nosniff" } }
+      );
+    }
     const openai = createOpenAI({ baseURL, apiKey });
 
     const { text } = await generateText({

--- a/src/lib/chat-providers.ts
+++ b/src/lib/chat-providers.ts
@@ -1,5 +1,11 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import { streamText } from "ai";
+import {
+  getInferenciaApiKey,
+  getInferenciaBaseUrl,
+  getInferenciaChatModel,
+  isInferenciaEnvConfigured,
+} from "@/lib/inferencia-config";
 
 /** OpenRouter free chat models (scanned 2026-06-10). Non-chat (audio/VL/safety) excluded. */
 export const OPENROUTER_FREE_FALLBACK_MODELS = [
@@ -51,7 +57,7 @@ function parseOpenRouterModels(): string[] {
 }
 
 export function isInferenciaConfigured(): boolean {
-  return Boolean(process.env.INFERENCIA_API_KEY?.trim() && process.env.INFERENCIA_BASE_URL?.trim());
+  return isInferenciaEnvConfigured();
 }
 
 export function isOpenRouterConfigured(): boolean {
@@ -66,15 +72,18 @@ export function buildChatProviderChain(): ChatProviderSpec[] {
   const chain: ChatProviderSpec[] = [];
 
   if (isInferenciaConfigured()) {
+    const baseURL = getInferenciaBaseUrl()!;
+    const apiKey = getInferenciaApiKey()!;
+    const model = getInferenciaChatModel();
     chain.push({
       id: "inferencia",
       label: "Inferencia",
-      model: process.env.INFERENCIA_CHAT_MODEL || "gemma4:e4b",
+      model,
       timeoutMs: INFERENCIA_FAST_FAIL_MS,
       createClient: () =>
         createOpenAI({
-          baseURL: process.env.INFERENCIA_BASE_URL!,
-          apiKey: process.env.INFERENCIA_API_KEY!,
+          baseURL,
+          apiKey,
         }),
     });
   }

--- a/src/lib/inferencia-config.ts
+++ b/src/lib/inferencia-config.ts
@@ -1,0 +1,50 @@
+/**
+ * Single source of truth for Inferencia chat settings.
+ * Import from here — do not hardcode model/base URL in routes.
+ */
+
+/** Production default: gemma4:12b on Pi Ollama (see Inferencia /health models list). */
+export const DEFAULT_INFERENCIA_CHAT_MODEL = "gemma4:12b";
+
+/** Coolify / homelab: inferencia container on Docker network. */
+export const DEFAULT_INFERENCIA_BASE_URL_COOLIFY = "http://inferencia:8080/v1"; // pragma: allowlist secret
+
+/** Public tunnel fallback (local dev / external probes only). */
+export const DEFAULT_INFERENCIA_BASE_URL_PUBLIC = "https://llm.menezmethod.com/v1"; // pragma: allowlist secret
+
+export function getInferenciaChatModel(): string {
+  const fromEnv = process.env.INFERENCIA_CHAT_MODEL?.trim();
+  return fromEnv || DEFAULT_INFERENCIA_CHAT_MODEL;
+}
+
+export function getInferenciaBaseUrl(): string | null {
+  const fromEnv = process.env.INFERENCIA_BASE_URL?.trim();
+  if (fromEnv) return fromEnv.replace(/\/$/, "");
+  if (process.env.COOLIFY === "1" || process.env.COOLIFY === "true") {
+    return DEFAULT_INFERENCIA_BASE_URL_COOLIFY;
+  }
+  return null;
+}
+
+export function getInferenciaApiKey(): string | null {
+  const key = process.env.INFERENCIA_API_KEY?.trim();
+  return key || null;
+}
+
+export function isInferenciaEnvConfigured(): boolean {
+  return Boolean(getInferenciaApiKey() && getInferenciaBaseUrl());
+}
+
+/** OpenAI-compatible models list URL from base URL. */
+export function inferenciaModelsUrl(baseURL?: string | null): string | null {
+  const base = (baseURL ?? getInferenciaBaseUrl())?.replace(/\/v1\/?$/, "");
+  if (!base) return null;
+  return `${base}/v1/models`;
+}
+
+/** Inferencia gateway /health (no auth). */
+export function inferenciaHealthUrl(baseURL?: string | null): string | null {
+  const base = (baseURL ?? getInferenciaBaseUrl())?.replace(/\/v1\/?$/, "");
+  if (!base) return null;
+  return `${base}/health`;
+}

--- a/src/lib/inferencia-health.ts
+++ b/src/lib/inferencia-health.ts
@@ -1,56 +1,95 @@
 /**
- * Lightweight Inferencia connectivity probe for /api/health.
- * Caches results briefly to avoid hammering the inference gateway on uptime checks.
+ * Inferencia connectivity probe for /api/health.
+ * Verifies /health AND authenticated /v1/models (catches API key mismatch).
  */
+
+import {
+  getInferenciaApiKey,
+  getInferenciaChatModel,
+  inferenciaHealthUrl,
+  inferenciaModelsUrl,
+} from "@/lib/inferencia-config";
 
 const CACHE_TTL_MS = 30_000;
 
 let cached:
-  | { status: "up" | "down" | "degraded"; latency_ms?: number; checked_at: number }
+  | {
+      status: "up" | "down" | "degraded";
+      latency_ms?: number;
+      model?: string;
+      checked_at: number;
+    }
   | null = null;
 
-function inferenciaHealthUrl(): string | null {
-  const baseURL = process.env.INFERENCIA_BASE_URL?.trim();
-  if (!baseURL) return null;
-  const origin = baseURL.replace(/\/v1\/?$/, "");
-  return `${origin}/health`;
-}
+type HealthBody = {
+  status?: string;
+  services?: { ollama?: { models?: Array<{ id: string }> } };
+};
 
 export async function probeInferenciaHealth(): Promise<{
   status: "up" | "down" | "degraded";
   latency_ms?: number;
+  model?: string;
 }> {
   if (cached && Date.now() - cached.checked_at < CACHE_TTL_MS) {
-    return { status: cached.status, latency_ms: cached.latency_ms };
+    const { status, latency_ms, model } = cached;
+    return { status, latency_ms, model };
   }
 
-  const apiKey = process.env.INFERENCIA_API_KEY;
+  const apiKey = getInferenciaApiKey();
   const healthUrl = inferenciaHealthUrl();
+  const modelsUrl = inferenciaModelsUrl();
+  const model = getInferenciaChatModel();
 
   if (!apiKey) {
-    const result = { status: "degraded" as const };
+    const result = { status: "degraded" as const, model };
     cached = { ...result, checked_at: Date.now() };
     return result;
   }
 
-  if (!healthUrl) {
-    const result = { status: "degraded" as const };
+  if (!healthUrl || !modelsUrl) {
+    const result = { status: "degraded" as const, model };
     cached = { ...result, checked_at: Date.now() };
     return result;
   }
 
   const start = Date.now();
   try {
-    const res = await fetch(healthUrl, { signal: AbortSignal.timeout(5000) });
+    const healthRes = await fetch(healthUrl, { signal: AbortSignal.timeout(5000) });
+    const healthBody = (await healthRes.json().catch(() => null)) as HealthBody | null;
+    const gatewayUp = healthRes.ok && healthBody?.status === "healthy";
+
+    if (!gatewayUp) {
+      const latency_ms = Date.now() - start;
+      const result = { status: "down" as const, latency_ms, model };
+      cached = { ...result, checked_at: Date.now() };
+      return result;
+    }
+
+    const ollamaModels = healthBody?.services?.ollama?.models?.map((m) => m.id) ?? [];
+    if (ollamaModels.length > 0 && !ollamaModels.includes(model)) {
+      const latency_ms = Date.now() - start;
+      const result = { status: "down" as const, latency_ms, model };
+      cached = { ...result, checked_at: Date.now() };
+      return result;
+    }
+
+    const authRes = await fetch(modelsUrl, {
+      signal: AbortSignal.timeout(5000),
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+
     const latency_ms = Date.now() - start;
-    const body = (await res.json().catch(() => null)) as { status?: string } | null;
-    const backendHealthy = res.ok && body?.status === "healthy";
-    const result = { status: backendHealthy ? ("up" as const) : ("down" as const), latency_ms };
+    const result = {
+      status: authRes.ok ? ("up" as const) : ("down" as const),
+      latency_ms,
+      model,
+    };
     cached = { ...result, checked_at: Date.now() };
     return result;
   } catch {
     const latency_ms = Date.now() - start;
-    const result = { status: "down" as const, latency_ms };
+    const result = { status: "down" as const, latency_ms, model };
     cached = { ...result, checked_at: Date.now() };
     return result;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Locks down Hermes and CI automations so they cannot break Inferencia again after your manual Coolify redeploy fixed chat.

## Hermes safeguards

- **`scripts/hermes/audit-automations.sh`** — scans `~/.hermes` and crontab for dangerous patterns (POST `/api/chat`, `docker restart` inferencia/ollama, `WATCHDOG_ENABLE_RECOVERY`, `vercel --prod`)
- **`scripts/hermes/policy.json`** — documented allow/deny rules and recommended 15-min report-only crons
- **`inferencia-watchdog.py`** — hard-blocks `WATCHDOG_ENABLE_RECOVERY` (report-only forever)
- **`install-watchdogs.sh`** — copies policy + audit script; runs audit on install

## Coolify chat hardening (from RCA)

- Auth probe on `/v1/models` (not unauthenticated `/health`)
- Default model `gemma4:12b` via `inferencia-config.ts`
- Pin `INFERENCIA_*` in `docker-compose.coolify.yml`
- `scripts/verify-coolify-chat.sh` for Pi-side RCA

## CI / deploy

- GitHub Actions deploy job comment clarifies **`COOLIFY_APP_UUID` = lgportfolio only**, never inferencia/ollama

## Run on Pi after merge

```bash
git pull
./scripts/hermes/install-watchdogs.sh
./scripts/hermes/audit-automations.sh
./scripts/verify-coolify-chat.sh
```

**Disable in Hermes/crontab:** any script that POSTs `/api/chat`, restarts inferencia/ollama, or enables auto-recovery.

## Verification

- `npm run lint` — 0 errors
- `npm run build` — pass
- `npm run test` — 214 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eace6395-f15d-4ad2-be14-8eed503f29c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eace6395-f15d-4ad2-be14-8eed503f29c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

