### PR TITLE
fix(hermes): cleanup legacy scripts and block env overrides

### DIFF
--- a/docs/DEPLOY-COOLIFY.md
+++ b/docs/DEPLOY-COOLIFY.md
@@ -106,9 +106,12 @@ War Room should show `metrics_source: prometheus` and Prometheus **UP**.
 After each `git pull` on the Pi:
 
 ```bash
-./scripts/hermes/install-watchdogs.sh   # sync safe watchdogs to ~/.hermes
-./scripts/hermes/audit-automations.sh   # fail if unsafe crons/scripts exist
+./scripts/hermes/cleanup-hermes.sh --apply   # archive legacy scripts that override env
+./scripts/hermes/install-watchdogs.sh        # sync safe watchdogs to ~/.hermes
+./scripts/hermes/audit-automations.sh        # fail if unsafe crons/scripts remain
 ```
+
+**Source of truth for chat env:** Coolify UI + `docker-compose.coolify.yml` + `.env.coolify`. Hermes must **never** write `INFERENCIA_API_KEY`, `INFERENCIA_BASE_URL`, or `INFERENCIA_CHAT_MODEL`.
 
 **Safe (report-only):**
 
@@ -116,12 +119,14 @@ After each `git pull` on the Pi:
 |------------|----------------|
 | `inferencia-watchdog.py` | GET Inferencia `/health` + shallow `/api/health` |
 | `portfolio-chat-watchdog.sh` | Same; never POST `/api/chat` |
+| `cleanup-hermes.sh` | Archives legacy recovery/override scripts from `~/.hermes` |
 | GitHub Actions `deploy` job | Redeploys **lgportfolio** Coolify app only (after CI) |
 
 **Never automate (caused outages):**
 
 - POST `https://gimenez.dev/api/chat` on a cron
 - `docker restart` / Coolify redeploy on **inferencia** or **ollama**
+- `sed` / `echo` to `.env.coolify` or `INFERENCIA_*` (overrides Coolify)
 - Hermes auto-recovery (`WATCHDOG_ENABLE_RECOVERY`) — permanently disabled in v2 scripts
 - Vercel `vercel --prod` from crons
 

--- a/docs/VERCEL-CLEANUP.md
+++ b/docs/VERCEL-CLEANUP.md
@@ -38,23 +38,27 @@ Old **Deployments** rows (`Production – lgportfolio-inline`, etc.) stay in Git
 - **Never** `vercel --prod` or `vercel rollback` from crons (report-only watchdogs)
 - Portfolio weekly audit → PR to `main`; humans merge; Vercel deploys once
 
-## Watchdogs (no chat POST spam, no auto-restart)
+## Watchdogs (no chat POST spam, no auto-restart, no env override)
 
-Install on Pi5 after each pull:
+On Pi5 after each pull:
 
 ```bash
+./scripts/hermes/cleanup-hermes.sh --apply
 ./scripts/hermes/install-watchdogs.sh
+./scripts/hermes/audit-automations.sh
 ```
 
 | Script | Safe behavior |
 |--------|----------------|
-| `scripts/hermes/inferencia-watchdog.py` | GET Inferencia `/health` + shallow portfolio health — **no POST /api/chat**, **no docker restart** |
-| `scripts/hermes-chat-watchdog.sh` | Same pattern (installed as `portfolio-chat-watchdog.sh`) |
+| `scripts/hermes/inferencia-watchdog.py` | GET Inferencia `/health` + shallow portfolio health |
+| `scripts/hermes/portfolio-chat-watchdog.sh` | Same — **no POST /api/chat**, **no docker restart** |
+| `scripts/hermes/cleanup-hermes.sh` | Archives legacy recovery scripts that mutate `INFERENCIA_*` / `.env.coolify` |
 
-**Remove from Hermes crons** (these break Inferencia):
+**Remove from Hermes crons** (these break Inferencia or override Coolify):
 
 - POST `https://gimenez.dev/api/chat` (loads Ollama, rate limits)
 - `docker restart` / Coolify auto-recovery on inferencia or ollama (502 storm)
+- `sed` / `echo` to `.env.coolify` or `INFERENCIA_*` env vars
 - Intervals under 10 minutes on inference checks
 
 Portfolio `/api/health?shallow=1` + header `X-Hermes-Watchdog: 1` skips the Inferencia probe cascade.

--- a/scripts/hermes-chat-watchdog.sh
+++ b/scripts/hermes-chat-watchdog.sh
@@ -1,41 +1,5 @@
 #!/usr/bin/env bash
-# Hermes no-agent cron watchdog for gimenez.dev + Inferencia chain.
-# Uses /api/health only — never POST /api/chat (avoids LLM spend + rate limits).
-#
-# Exit 0 + empty stdout = healthy (silent)
-# Exit 0 + stdout         = alert delivered
-
+# Back-compat wrapper — canonical script lives in scripts/hermes/.
 set -euo pipefail
-
-SITE_URL="${SITE_URL:-https://gimenez.dev}"
-HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-10}"
-
-fail() {
-  echo "portfolio-chat-watchdog: $*"
-  exit 0
-}
-
-# Shallow health — does not cascade into Inferencia /health (see /api/health?shallow=1)
-health_json="$(curl -fsS --max-time "$HEALTH_TIMEOUT" \
-  -H "X-Hermes-Watchdog: 1" \
-  "${SITE_URL}/api/health?shallow=1")" || fail "GET /api/health?shallow=1 failed"
-
-site_status="$(printf '%s' "$health_json" | python3 -c "import json,sys; print(json.load(sys.stdin)['status'])" 2>/dev/null || echo unknown)"
-if [ "$site_status" != "healthy" ] && [ "$site_status" != "degraded" ]; then
-  fail "/api/health status=${site_status} (expected healthy or degraded)"
-fi
-
-# Inferencia direct — /health only, never POST /v1/chat/completions
-inferencia_health="${INFERENCIA_HEALTH_URL:-https://llm.menezmethod.com/health}"
-infer_code="$(curl -sS --max-time "$HEALTH_TIMEOUT" -o /dev/null -w '%{http_code}' "$inferencia_health" || echo 000)"
-if [ "$infer_code" != "200" ]; then
-  fail "Inferencia GET ${inferencia_health} returned HTTP ${infer_code}"
-fi
-
-# Chat route alive (HEAD — no inference call)
-chat_code="$(curl -sS --max-time "$HEALTH_TIMEOUT" -o /dev/null -w '%{http_code}' -X HEAD "${SITE_URL}/api/chat" || echo 000)"
-if [ "$chat_code" != "405" ] && [ "$chat_code" != "200" ]; then
-  fail "HEAD /api/chat returned HTTP ${chat_code} (expected 405 or 200)"
-fi
-
-exit 0
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+exec "$REPO_ROOT/scripts/hermes/portfolio-chat-watchdog.sh" "$@"

--- a/scripts/hermes/audit-automations.sh
+++ b/scripts/hermes/audit-automations.sh
@@ -38,6 +38,15 @@ scan_file() {
   if rg -qi 'vercel\s+(--prod|rollback)' "$f" 2>/dev/null; then
     warn "$rel — Vercel prod deploy/rollback from cron"
   fi
+  if rg -qi '(sed|echo|printf|tee).*(INFERENCIA_|\.env\.coolify)' "$f" 2>/dev/null; then
+    warn "$rel — mutates INFERENCIA_* or .env.coolify (overrides Coolify)"
+  fi
+  if rg -qi 'coolify.*(env|environment|variables)' "$f" 2>/dev/null; then
+    warn "$rel — Coolify env variable override"
+  fi
+  if rg -qi 'docker\s+exec.*(INFERENCIA_|export\s)' "$f" 2>/dev/null; then
+    warn "$rel — docker exec env override"
+  fi
 }
 
 echo "=== Hermes / automation safety audit ==="
@@ -69,7 +78,7 @@ if crontab -l 2>/dev/null | rg -i 'hermes|inferencia-watchdog|portfolio-chat' >/
   cat /tmp/hermes-cron.txt
   while IFS= read -r line; do
     case "$line" in \#*|"") continue ;; esac
-    if echo "$line" | rg -qi 'api/chat|docker restart|enable_recovery'; then
+    if echo "$line" | rg -qi 'api/chat|docker restart|enable_recovery|INFERENCIA_|\.env\.coolify|coolify.*deploy'; then
       warn "crontab: $line"
     else
       ok "crontab: $line"

--- a/scripts/hermes/cleanup-hermes.sh
+++ b/scripts/hermes/cleanup-hermes.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Remove legacy Hermes scripts that override Coolify/Inferencia env or restart containers.
+#
+# Default: dry-run (prints what would change).
+# Apply:   ./scripts/hermes/cleanup-hermes.sh --apply
+#
+# Run on Pi after git pull, before install-watchdogs.sh.
+
+set -euo pipefail
+
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+SCRIPTS_DIR="${HERMES_HOME}/scripts"
+ARCHIVE_DIR="${HERMES_HOME}/archive/$(date +%Y%m%d-%H%M%S)"
+APPLY=false
+MOVED=0
+DISABLED_CRONS=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --apply) APPLY=true ;;
+    -h|--help)
+      echo "Usage: $0 [--apply]"
+      echo "  Archives unsafe ~/.hermes scripts and disables matching crontab lines."
+      exit 0
+      ;;
+  esac
+done
+
+# Only these filenames may stay in ~/.hermes/scripts (report-only watchdogs).
+ALLOWLIST=(
+  inferencia-watchdog.py
+  portfolio-chat-watchdog.sh
+  audit-automations.sh
+  cleanup-hermes.sh
+  policy.json
+  vercel-governor.py
+)
+
+is_allowlisted() {
+  local base="$1"
+  local f
+  for f in "${ALLOWLIST[@]}"; do
+    if [ "$base" = "$f" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+file_is_unsafe() {
+  local f="$1"
+  [ -f "$f" ] || return 1
+  if rg -qi 'POST.*(/api/chat|chat/completions)' "$f" 2>/dev/null; then return 0; fi
+  if rg -qi 'docker\s+(restart|rm|stop|kill).*(inferencia|ollama)' "$f" 2>/dev/null; then return 0; fi
+  if rg -qi 'coolify.*(restart|redeploy|deploy)' "$f" 2>/dev/null; then return 0; fi
+  if rg -qi '(sed|echo|printf).*(INFERENCIA_|\.env\.coolify)' "$f" 2>/dev/null; then return 0; fi
+  if rg -qi 'WATCHDOG_ENABLE_RECOVERY\s*=\s*(1|true|yes)' "$f" 2>/dev/null; then return 0; fi
+  if rg -qi 'vercel\s+(--prod|rollback)' "$f" 2>/dev/null; then return 0; fi
+  return 1
+}
+
+legacy_name() {
+  local base="$1"
+  case "$base" in
+    *recovery*|*heal*|*fix-env*|*fix_env*|*chat-health*|*inferencia-monitor*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+cron_is_unsafe() {
+  echo "$1" | rg -qi 'api/chat|docker restart|enable_recovery|INFERENCIA_|\.env\.coolify|coolify.*deploy'
+}
+
+archive_file() {
+  local f="$1"
+  local reason="$2"
+  local rel="${f#$HERMES_HOME/}"
+  if [ "$APPLY" = true ]; then
+    mkdir -p "$ARCHIVE_DIR"
+    mkdir -p "$(dirname "${ARCHIVE_DIR}/${rel}")"
+    mv "$f" "${ARCHIVE_DIR}/${rel}"
+    echo "ARCHIVED: $rel ($reason) → ${ARCHIVE_DIR}/${rel}"
+  else
+    echo "WOULD ARCHIVE: $rel ($reason)"
+  fi
+  MOVED=$((MOVED + 1))
+}
+
+echo "=== Hermes cleanup (override + legacy script removal) ==="
+echo "HERMES_HOME=$HERMES_HOME"
+echo "mode=$([ "$APPLY" = true ] && echo apply || echo dry-run)"
+echo
+
+if [ ! -d "$HERMES_HOME" ]; then
+  echo "Nothing to clean — $HERMES_HOME does not exist."
+  exit 0
+fi
+
+if [ -d "$SCRIPTS_DIR" ]; then
+  while IFS= read -r -d '' f; do
+    base="$(basename "$f")"
+    if is_allowlisted "$base"; then
+      if file_is_unsafe "$f"; then
+        archive_file "$f" "allowlisted name but unsafe content — replaced on next install"
+      else
+        echo "KEEP: scripts/$base"
+      fi
+      continue
+    fi
+    if legacy_name "$base" || file_is_unsafe "$f"; then
+      archive_file "$f" "legacy or unsafe automation"
+    else
+      echo "REVIEW: scripts/$base (not on allowlist — not auto-removed)"
+    fi
+  done < <(find "$SCRIPTS_DIR" -type f \( -name '*.sh' -o -name '*.py' \) -print0 2>/dev/null)
+fi
+
+if crontab -l 2>/dev/null >/tmp/hermes-cron-full.txt; then
+  while IFS= read -r line; do
+    case "$line" in
+      \#*|"") continue ;;
+    esac
+    if cron_is_unsafe "$line"; then
+      if [ "$APPLY" = true ]; then
+        echo "DISABLED CRON: $line"
+      else
+        echo "WOULD DISABLE CRON: $line"
+      fi
+      DISABLED_CRONS=$((DISABLED_CRONS + 1))
+    fi
+  done < /tmp/hermes-cron-full.txt
+
+  if [ "$APPLY" = true ] && [ "$DISABLED_CRONS" -gt 0 ]; then
+    crontab -l 2>/dev/null | while IFS= read -r line; do
+      case "$line" in
+        \#HERMES-DISABLED*)
+          echo "$line"
+          ;;
+        *)
+          if cron_is_unsafe "$line"; then
+            echo "# HERMES-DISABLED $(date -Iseconds) — $line"
+          else
+            echo "$line"
+          fi
+          ;;
+      esac
+    done | crontab -
+  fi
+fi
+
+echo
+echo "Summary: archived/moved=$MOVED disabled_crons=$DISABLED_CRONS"
+if [ "$APPLY" = false ] && { [ "$MOVED" -gt 0 ] || [ "$DISABLED_CRONS" -gt 0 ]; }; then
+  echo "Re-run with --apply to apply changes, then: ./scripts/hermes/install-watchdogs.sh"
+fi
+
+if [ "$MOVED" -gt 0 ] || [ "$DISABLED_CRONS" -gt 0 ]; then
+  exit 1
+fi
+
+echo "CLEAN: no legacy override scripts or crons found."
+exit 0

--- a/scripts/hermes/install-watchdogs.sh
+++ b/scripts/hermes/install-watchdogs.sh
@@ -3,43 +3,50 @@
 #
 # Usage (on Pi5 after git pull):
 #   cd /path/to/lgportfolio
+#   ./scripts/hermes/cleanup-hermes.sh --apply   # remove legacy override scripts first
 #   ./scripts/hermes/install-watchdogs.sh
 #
-# Then update Hermes cron entries to call:
-#   python3 ~/.hermes/scripts/inferencia-watchdog.py
-#   bash ~/.hermes/scripts/portfolio-chat-watchdog.sh
-#
-# REMOVE any cron that POSTs /api/chat or runs docker/coolify restart.
+# Hermes must never mutate INFERENCIA_* or .env.coolify — Coolify is source of truth.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 DEST="${HERMES_HOME:-$HOME/.hermes}/scripts"
 
+echo "==> Cleaning legacy Hermes scripts (dry-run)..."
+"$REPO_ROOT/scripts/hermes/cleanup-hermes.sh" || true
+echo "    Run ./scripts/hermes/cleanup-hermes.sh --apply on Pi to archive unsafe scripts."
+
 mkdir -p "$DEST"
 
 install -m 755 "$REPO_ROOT/scripts/hermes/inferencia-watchdog.py" "$DEST/inferencia-watchdog.py"
-install -m 755 "$REPO_ROOT/scripts/hermes-chat-watchdog.sh" "$DEST/portfolio-chat-watchdog.sh"
+install -m 755 "$REPO_ROOT/scripts/hermes/portfolio-chat-watchdog.sh" "$DEST/portfolio-chat-watchdog.sh"
 install -m 644 "$REPO_ROOT/scripts/hermes/policy.json" "$DEST/policy.json"
 install -m 755 "$REPO_ROOT/scripts/hermes/audit-automations.sh" "$DEST/audit-automations.sh"
+install -m 755 "$REPO_ROOT/scripts/hermes/cleanup-hermes.sh" "$DEST/cleanup-hermes.sh"
+
+echo "policy_version=3" > "${HERMES_HOME:-$HOME/.hermes}/.installed-version"
 
 echo "Running safety audit..."
 if "$DEST/audit-automations.sh"; then
   echo "Audit passed."
 else
-  echo "WARN: audit found unsafe patterns — review ~/.hermes and crontab (see policy.json)"
+  echo "WARN: audit found unsafe patterns — run: $DEST/cleanup-hermes.sh --apply"
 fi
 
 cat <<EOF
 Installed safe watchdogs to ${DEST}:
-  - inferencia-watchdog.py   (GET /health only, no recovery)
-  - portfolio-chat-watchdog.sh (shallow /api/health, no POST /api/chat)
+  - inferencia-watchdog.py      (GET /health only, no recovery)
+  - portfolio-chat-watchdog.sh  (shallow /api/health, no POST /api/chat)
+  - cleanup-hermes.sh           (archive legacy override scripts)
+  - policy.json                 (allowlist + do-not-override env vars)
 
-Hermes cron (no_agent: true, every 10-15 min — not 5 min):
+Hermes cron (no_agent: true, every 15 min):
   inferencia: python3 ${DEST}/inferencia-watchdog.py
   portfolio:  bash ${DEST}/portfolio-chat-watchdog.sh
 
-DISABLE in Hermes / crontab:
-  - Any script that POSTs https://gimenez.dev/api/chat
-  - Any script that docker restart / coolify redeploy on inferencia or ollama
+NEVER automate (overrides Coolify / caused outages):
+  - POST https://gimenez.dev/api/chat
+  - docker restart / coolify redeploy on inferencia or ollama
+  - sed/echo to INFERENCIA_* or .env.coolify
 EOF

--- a/scripts/hermes/policy.json
+++ b/scripts/hermes/policy.json
@@ -1,6 +1,6 @@
 {
-  "policy_version": 2,
-  "description": "Hermes cron policy for gimenez.dev + Inferencia — report-only, no recovery",
+  "policy_version": 3,
+  "description": "Hermes cron policy for gimenez.dev + Inferencia — report-only, no recovery, no env overrides",
   "rules": {
     "allowed_http": ["GET /health", "GET /api/health?shallow=1", "HEAD /api/chat"],
     "forbidden_http": ["POST /api/chat", "POST /v1/chat/completions"],
@@ -8,11 +8,33 @@
       "docker restart inferencia",
       "docker restart ollama",
       "coolify redeploy inferencia",
+      "coolify env variable changes",
+      "mutate .env.coolify",
+      "mutate INFERENCIA_API_KEY",
+      "mutate INFERENCIA_BASE_URL",
+      "mutate INFERENCIA_CHAT_MODEL",
       "vercel --prod",
       "WATCHDOG_ENABLE_RECOVERY"
     ],
     "min_interval_minutes": 10,
     "no_agent": true
+  },
+  "allowlisted_scripts": [
+    "inferencia-watchdog.py",
+    "portfolio-chat-watchdog.sh",
+    "audit-automations.sh",
+    "cleanup-hermes.sh",
+    "policy.json",
+    "vercel-governor.py"
+  ],
+  "do_not_override": {
+    "source_of_truth": "Coolify UI + docker-compose.coolify.yml + .env.coolify on Pi",
+    "env_vars": [
+      "INFERENCIA_API_KEY",
+      "INFERENCIA_BASE_URL",
+      "INFERENCIA_CHAT_MODEL"
+    ],
+    "notes": "Hermes must never write these — mismatched keys caused 503 chat outages"
   },
   "recommended_crons": [
     {

--- a/scripts/hermes/portfolio-chat-watchdog.sh
+++ b/scripts/hermes/portfolio-chat-watchdog.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Hermes no-agent cron watchdog for gimenez.dev + Inferencia chain.
+# Uses /api/health only — never POST /api/chat (avoids LLM spend + rate limits).
+#
+# Exit 0 + empty stdout = healthy (silent)
+# Exit 0 + stdout         = alert delivered
+
+set -euo pipefail
+
+SITE_URL="${SITE_URL:-https://gimenez.dev}"
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-10}"
+
+fail() {
+  echo "portfolio-chat-watchdog: $*"
+  exit 0
+}
+
+# Shallow health — does not cascade into Inferencia /health (see /api/health?shallow=1)
+health_json="$(curl -fsS --max-time "$HEALTH_TIMEOUT" \
+  -H "X-Hermes-Watchdog: 1" \
+  "${SITE_URL}/api/health?shallow=1")" || fail "GET /api/health?shallow=1 failed"
+
+site_status="$(printf '%s' "$health_json" | python3 -c "import json,sys; print(json.load(sys.stdin)['status'])" 2>/dev/null || echo unknown)"
+if [ "$site_status" != "healthy" ] && [ "$site_status" != "degraded" ]; then
+  fail "/api/health status=${site_status} (expected healthy or degraded)"
+fi
+
+# Inferencia direct — /health only, never POST /v1/chat/completions
+inferencia_health="${INFERENCIA_HEALTH_URL:-https://llm.menezmethod.com/health}"
+infer_code="$(curl -sS --max-time "$HEALTH_TIMEOUT" -o /dev/null -w '%{http_code}' "$inferencia_health" || echo 000)"
+if [ "$infer_code" != "200" ]; then
+  fail "Inferencia GET ${inferencia_health} returned HTTP ${infer_code}"
+fi
+
+# Chat route alive (HEAD — no inference call)
+chat_code="$(curl -sS --max-time "$HEALTH_TIMEOUT" -o /dev/null -w '%{http_code}' -X HEAD "${SITE_URL}/api/chat" || echo 000)"
+if [ "$chat_code" != "405" ] && [ "$chat_code" != "200" ]; then
+  fail "HEAD /api/chat returned HTTP ${chat_code} (expected 405 or 200)"
+fi
+
+exit 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cleans up legacy Hermes automations that overrode Coolify/Inferencia settings and caused chat outages.

## Changes

- **`cleanup-hermes.sh`** — dry-run by default; `--apply` archives unsafe `~/.hermes` scripts and disables matching crontab lines (POST `/api/chat`, docker restart, `INFERENCIA_*` / `.env.coolify` mutation)
- **`portfolio-chat-watchdog.sh`** moved under `scripts/hermes/` (wrapper kept for back-compat)
- **`audit-automations.sh`** — detects env override patterns (`sed`/`echo` to `INFERENCIA_*`, Coolify env API)
- **`policy.json` v3** — allowlisted scripts + `do_not_override` for `INFERENCIA_API_KEY`, `INFERENCIA_BASE_URL`, `INFERENCIA_CHAT_MODEL`
- **`install-watchdogs.sh`** — runs cleanup dry-run first, writes `.installed-version`

## Run on Pi after merge

```bash
git pull
./scripts/hermes/cleanup-hermes.sh --apply
./scripts/hermes/install-watchdogs.sh
./scripts/hermes/audit-automations.sh
```

Coolify + `.env.coolify` remain the only source of truth for Inferencia env — Hermes is report-only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eace6395-f15d-4ad2-be14-8eed503f29c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eace6395-f15d-4ad2-be14-8eed503f29c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

