### PR TITLE
chore(ci): remove Terraform from pipeline (Coolify-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
-# CI: lint, build, unit tests, e2e (Cypress), Terraform validate.
+# CI: lint, build, unit tests, e2e (Cypress).
 # Required to pass before merging to main. On push to main, deploys to Coolify (Pi) after all checks pass.
+# Terraform (terraform/) is kept for optional GCP rollback only — not run in CI.
 
 name: CI
 
@@ -14,30 +15,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  terraform:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "1.5.0"
-          terraform_wrapper: false
-
-      - name: Terraform fmt check
-        run: terraform fmt -check -recursive
-        working-directory: terraform
-
-      - name: Terraform init and validate
-        run: |
-          terraform init -input=false -backend=false
-          terraform validate
-        working-directory: terraform
-
   lint-build-test:
     runs-on: ubuntu-latest
-    needs: terraform
     steps:
       - uses: actions/checkout@v4
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Analytics: **Google Analytics 4 only** (optional `NEXT_PUBLIC_GA_MEASUREMENT_ID`
 - `npm run build` — production build (`standalone` output for Docker/Coolify — see `next.config.ts`)
 - `npm run lint` — ESLint (currently 0 errors, 0 warnings)
 
-**Verify before commit / after changes:** Run `npm run build`, `npm run lint`, and `cd terraform && terraform init -input=false && terraform validate`. All must pass.
+**Verify before commit / after changes:** Run `npm run build`, `npm run lint`, and `npm run test`. Terraform (`terraform/`) is optional — only if you are working on the GCP rollback path.
 
 ### Key routes
 

--- a/docs/CI-AND-TESTS.md
+++ b/docs/CI-AND-TESTS.md
@@ -9,6 +9,8 @@
 
 The **GitHub Actions workflow** (`.github/workflows/ci.yml`) runs on every **pull request to `main`** and on **push to `main`**. It runs lint, build, unit tests, and Cypress. On **push to `main` only**, after all checks pass, it triggers a **Coolify deploy** (homelab Pi) via the Coolify API.
 
+**Terraform is not in CI.** The `terraform/` directory remains for optional GCP rollback (`docs/DEPLOY-CLOUDRUN.md`); validate manually if you change it.
+
 ### Coolify deploy secrets (GitHub → Settings → Secrets)
 
 | Secret | Example / where to get it |


### PR DESCRIPTION
## Summary
- Remove the `terraform` job from GitHub Actions CI entirely
- CI is now Coolify-only: lint → build → unit tests → Cypress → Coolify deploy on `main`
- `terraform/` and `cloudbuild.yaml` stay in-repo for manual GCP rollback but are not invoked by CI

## Test plan
- [ ] PR CI passes with only `lint-build-test` and `cypress` (no `terraform` job)
- [ ] Merge triggers Coolify deploy on main


Made with [Cursor](https://cursor.com)