### PR TITLE
fix: redirect /projects and /resume to prevent 404s

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -32,6 +32,20 @@ const nextConfig: NextConfig = {
     unoptimized: true,
   },
   poweredByHeader: false,
+  async redirects() {
+    return [
+      {
+        source: "/projects",
+        destination: "/work",
+        permanent: true,
+      },
+      {
+        source: "/resume",
+        destination: "/contact",
+        permanent: true,
+      },
+    ];
+  },
   async headers() {
     // Cache static pages at CDN and browser (free-tier friendly when traffic spikes)
     const staticCache = "public, max-age=3600, s-maxage=3600, stale-while-revalidate=60";


### PR DESCRIPTION
## What
Adds 308 permanent redirects in next.config.ts:
- /projects -> /work
- /resume -> /contact

Old links from the prior portfolio still circulate and hit 404. These redirects send visitors to the correct pages.

## Verification
Locally confirmed both routes return 308 Permanent Redirect with correct location headers.
Build succeeded (Next.js standalone, no new dependencies).
